### PR TITLE
fix clean up expired leases

### DIFF
--- a/fenzo-core/src/main/java/com/netflix/fenzo/TaskScheduler.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/TaskScheduler.java
@@ -364,7 +364,6 @@ public class TaskScheduler {
                 }
             }
         }
-        rejectedCount.addAndGet(assignableVMs.cleanup());
         List<VirtualMachineLease> idleResourcesList = new ArrayList<>();
         for(AssignableVirtualMachine avm: avms) {
             VMAssignmentResult assignmentResult = avm.resetAndGetSuccessfullyAssignedRequests();
@@ -376,6 +375,7 @@ public class TaskScheduler {
                 resultMap.put(avm.getHostname(), assignmentResult);
             }
         }
+        rejectedCount.addAndGet(assignableVMs.removeLimitedLeases(idleResourcesList));
         final AutoScalerInput autoScalerInput = new AutoScalerInput(idleResourcesList, failedTasksForAutoScaler);
         if(autoScaler!=null)
             autoScaler.scheduleAutoscale(autoScalerInput);

--- a/fenzo-core/src/test/java/com/netflix/fenzo/ActiveVmGroupsTests.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/ActiveVmGroupsTests.java
@@ -71,11 +71,11 @@ public class ActiveVmGroupsTests {
     public void testInactiveVmGroup() {
         List<VirtualMachineLease.Range> ports = new ArrayList<>();
         ports.add(new VirtualMachineLease.Range(1, 10));
-        List<VirtualMachineLease> leases = Arrays.asList(LeaseProvider.getLeaseOffer("host1", 4, 4000, ports, attributes2));
-        List<TaskRequest> tasks = Arrays.asList(TaskRequestProvider.getTaskRequest(1, 1000, 1));
+        List<VirtualMachineLease> leases = Collections.singletonList(LeaseProvider.getLeaseOffer("host1", 4, 4000, ports, attributes2));
+        List<TaskRequest> tasks = Collections.singletonList(TaskRequestProvider.getTaskRequest(1, 1000, 1));
         Map<String, VMAssignmentResult> resultMap = taskScheduler.scheduleOnce(tasks, leases).getResultMap();
         Assert.assertEquals(0, resultMap.size());
-        leases = Arrays.asList(LeaseProvider.getLeaseOffer("host2", 4, 4000, ports, attributes1));
+        leases = Collections.singletonList(LeaseProvider.getLeaseOffer("host2", 4, 4000, ports, attributes1));
         resultMap = taskScheduler.scheduleOnce(tasks, leases).getResultMap();
         Assert.assertEquals(1, resultMap.size());
         Assert.assertEquals(tasks.get(0).getId(), resultMap.values().iterator().next().getTasksAssigned().iterator().next().getTaskId());

--- a/fenzo-core/src/test/java/com/netflix/fenzo/AutoScalerTest.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/AutoScalerTest.java
@@ -272,7 +272,7 @@ public class AutoScalerTest {
         boolean first=true;
         do {
             Thread.sleep(1000);
-            scheduler.scheduleOnce(requests, leases);
+            final SchedulingResult schedulingResult = scheduler.scheduleOnce(requests, leases);
             if(first) {
                 first=false;
                 leases.clear();


### PR DESCRIPTION
- separated out removing expired leases from random removal of a subset of active leases
- new test to verify expired leases are not used for allocation
