### PR TITLE
IntervalTrigger support added based on ISO-8601 interval format

### DIFF
--- a/fenzo-triggers/fenzo-triggers.gradle
+++ b/fenzo-triggers/fenzo-triggers.gradle
@@ -18,6 +18,7 @@ apply plugin: 'groovy'
 
 dependencies {
     compile ("org.quartz-scheduler:quartz:latest.release")
+    compile("joda-time:joda-time:latest.release")
     compile ("io.reactivex:rxjava:latest.release")
     compile ("com.fasterxml.jackson.core:jackson-annotations:latest.release")
     testCompile ("org.codehaus.groovy:groovy-all:latest.release")

--- a/fenzo-triggers/src/main/java/com/netflix/fenzo/triggers/CronTrigger.java
+++ b/fenzo-triggers/src/main/java/com/netflix/fenzo/triggers/CronTrigger.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.quartz.ScheduleBuilder;
 import rx.functions.Action1;
 
+import java.util.Date;
+
 import static org.quartz.CronScheduleBuilder.cronSchedule;
 
 /**
@@ -38,7 +40,7 @@ public class CronTrigger<T> extends ScheduledTrigger<T> {
                        @JsonProperty("data") T data,
                        @JsonProperty("dataType") Class<T> dataType,
                        @JsonProperty("action") Class<? extends Action1<T>> action) {
-        super(name, data, dataType, action);
+        super(name, data, dataType, action, new Date(), null);
         this.cronExpression = cronExpression;
     }
 

--- a/fenzo-triggers/src/main/java/com/netflix/fenzo/triggers/IntervalTrigger.java
+++ b/fenzo-triggers/src/main/java/com/netflix/fenzo/triggers/IntervalTrigger.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.fenzo.triggers;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.joda.time.Interval;
+import org.quartz.ScheduleBuilder;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.SimpleTrigger;
+import org.quartz.Trigger;
+import org.quartz.spi.MutableTrigger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.functions.Action1;
+
+public class IntervalTrigger<T> extends ScheduledTrigger<T> {
+    private static final Logger logger = LoggerFactory.getLogger(IntervalTrigger.class);
+    final private long repeatInterval;
+    final private int repeatCount;
+
+    public IntervalTrigger(
+            @JsonProperty("iso8601Interval") String interval,
+            @JsonProperty("repeatCount") int repeatCount,
+            @JsonProperty("name") String name,
+            @JsonProperty("data") T data,
+            @JsonProperty("dataType") Class<T> dataType,
+            @JsonProperty("action") Class<? extends Action1<T>> action) {
+        super(name, data, dataType, action, Interval.parse(interval).getStart().toDate(), null);
+
+        final Interval jodaInterval = Interval.parse(interval);
+        this.repeatCount = repeatCount; // -1 = indefinitely repeat
+        repeatInterval = Interval.parse(interval).getEndMillis() - jodaInterval.getStartMillis();
+    }
+
+    @Override
+    public ScheduleBuilder getScheduleBuilder() {
+        return new ScheduleBuilder<SimpleTrigger>() {
+            @Override
+            protected MutableTrigger build() {
+                return SimpleScheduleBuilder.simpleSchedule()
+                        .withRepeatCount(repeatCount)
+                        .withIntervalInMilliseconds(repeatInterval)
+                        .build();
+            }
+        };
+    }
+
+    @Override
+    public void setQuartzTrigger(Trigger quartzTrigger) {
+        logger.info("Setting QuartzTrigger " + quartzTrigger);
+    }
+}

--- a/fenzo-triggers/src/main/java/com/netflix/fenzo/triggers/ScheduledTrigger.java
+++ b/fenzo-triggers/src/main/java/com/netflix/fenzo/triggers/ScheduledTrigger.java
@@ -21,21 +21,37 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.quartz.ScheduleBuilder;
 import rx.functions.Action1;
 
+import java.util.Date;
+
 /**
  * Placeholder super class for all the triggers that can be scheduled.
- *
  */
 public abstract class ScheduledTrigger<T> extends Trigger<T> {
+    final private Date startAt;
+    final private Date endAt;
 
     @JsonCreator
-    public ScheduledTrigger(@JsonProperty("name") String name,
-                            @JsonProperty("data") T data,
-                            @JsonProperty("dataType") Class<T> dataType,
-                            @JsonProperty("action") Class<? extends Action1<T>> action) {
+    public ScheduledTrigger(
+            @JsonProperty("name") String name,
+            @JsonProperty("data") T data,
+            @JsonProperty("dataType") Class<T> dataType,
+            @JsonProperty("action") Class<? extends Action1<T>> action,
+            @JsonProperty("startAt") Date startAt,
+            @JsonProperty("endAt") Date endAt) {
         super(name, data, dataType, action);
+        this.startAt = startAt;
+        this.endAt = endAt;
     }
 
     public abstract ScheduleBuilder getScheduleBuilder();
 
     public abstract void setQuartzTrigger(org.quartz.Trigger quartzTrigger);
+
+    public Date getStartAt() {
+        return startAt;
+    }
+
+    public Date getEndAt() {
+        return endAt;
+    }
 }

--- a/fenzo-triggers/src/main/java/com/netflix/fenzo/triggers/TriggerOperator.java
+++ b/fenzo-triggers/src/main/java/com/netflix/fenzo/triggers/TriggerOperator.java
@@ -55,7 +55,8 @@ public class TriggerOperator {
 
     /**
      * Constructor
-     * @param triggerDao - dao implementation for {@code Trigger}
+     *
+     * @param triggerDao     - dao implementation for {@code Trigger}
      * @param threadPoolSize - the thread pool size for the scheduler
      */
     public TriggerOperator(TriggerDao triggerDao, int threadPoolSize) {
@@ -66,6 +67,7 @@ public class TriggerOperator {
 
     /**
      * Users of this class must call {@code initialize()} before using this class
+     *
      * @throws SchedulerException
      */
     @PostConstruct
@@ -76,7 +78,7 @@ public class TriggerOperator {
             } catch (org.quartz.SchedulerException se) {
                 throw new SchedulerException("Exception occurred while initializing TriggerOperator", se);
             }
-            for (Iterator<Trigger> iterator = getTriggers().iterator(); iterator.hasNext();) {
+            for (Iterator<Trigger> iterator = getTriggers().iterator(); iterator.hasNext(); ) {
                 Trigger trigger = iterator.next();
                 if (!trigger.isDisabled() && trigger instanceof ScheduledTrigger) {
                     scheduleTrigger((ScheduledTrigger) trigger);
@@ -99,6 +101,7 @@ public class TriggerOperator {
     /**
      * Returns a default instance of {@code TriggerOperator} with sensible default values.
      * Uses an in-memory implementation of Dao.
+     *
      * @return
      */
     public static TriggerOperator getInstance() {
@@ -106,7 +109,6 @@ public class TriggerOperator {
     }
 
     /**
-     *
      * @param threadPoolSize
      * @return
      */
@@ -115,7 +117,6 @@ public class TriggerOperator {
     }
 
     /**
-     *
      * @param triggerDao
      * @param threadPoolSize
      * @return
@@ -126,6 +127,7 @@ public class TriggerOperator {
 
     /**
      * Returns the {@code Trigger} based on the unique trigger id
+     *
      * @param triggerId
      * @return
      */
@@ -135,6 +137,7 @@ public class TriggerOperator {
 
     /**
      * Registers a {@code Trigger} with trigger service
+     *
      * @param triggerGroup
      * @param trigger
      * @throws SchedulerException
@@ -149,6 +152,7 @@ public class TriggerOperator {
 
     /**
      * Disables the {@code Trigger}. If the {@code Trigger} is disabled it will NOT execute
+     *
      * @param triggerId
      * @throws TriggerNotFoundException
      * @throws SchedulerException
@@ -164,6 +168,7 @@ public class TriggerOperator {
 
     /**
      * Disables the {@code Trigger}. If the {@code Trigger} is disabled it will NOT execute
+     *
      * @param trigger
      * @throws TriggerNotFoundException
      * @throws SchedulerException
@@ -178,6 +183,7 @@ public class TriggerOperator {
 
     /**
      * Enables the {@code Trigger}
+     *
      * @param triggerId
      * @throws TriggerNotFoundException
      * @throws SchedulerException
@@ -193,6 +199,7 @@ public class TriggerOperator {
 
     /**
      * Enables the {@code Trigger}
+     *
      * @param trigger
      * @throws SchedulerException
      */
@@ -207,6 +214,7 @@ public class TriggerOperator {
     /**
      * Deletes/Removes the {@code Trigger}. If it is a {@code ScheduledTrigger} then it is also un-scheduled from
      * scheduler
+     *
      * @param triggerId
      * @throws TriggerNotFoundException
      * @throws SchedulerException
@@ -223,6 +231,7 @@ public class TriggerOperator {
     /**
      * Deletes/Removes the {@code Trigger}. If it is a {@code ScheduledTrigger} then it is also un-scheduled from
      * scheduler
+     *
      * @param trigger
      * @throws TriggerNotFoundException
      * @throws SchedulerException
@@ -236,21 +245,24 @@ public class TriggerOperator {
 
     /**
      * Schedules the {@code Trigger} using the scheduler
+     *
      * @param scheduledTrigger
      * @throws SchedulerException
      */
     public void scheduleTrigger(ScheduledTrigger scheduledTrigger) throws SchedulerException {
-        if (!initialized.get()) throw new SchedulerException("Trigger service is not initialized. initialize() must be called before calling scheduleTrigger() method");
+        if (!initialized.get())
+            throw new SchedulerException("Trigger service is not initialized. initialize() must be called before calling scheduleTrigger() method");
         Map jobDataMap = new HashMap();
         jobDataMap.put(TRIGGER_OPERATOR_KEY, this);
         jobDataMap.put(TRIGGER_KEY, scheduledTrigger);
         try {
             org.quartz.Trigger quartzTrigger = newTrigger()
-                .withIdentity(triggerKey(scheduledTrigger.getId(), Scheduler.DEFAULT_GROUP))
-                .withSchedule(scheduledTrigger.getScheduleBuilder())
-                .usingJobData(new JobDataMap(jobDataMap))
-                .startNow()
-                .build();
+                    .withIdentity(triggerKey(scheduledTrigger.getId(), Scheduler.DEFAULT_GROUP))
+                    .withSchedule(scheduledTrigger.getScheduleBuilder())
+                    .usingJobData(new JobDataMap(jobDataMap))
+                    .startAt(scheduledTrigger.getStartAt())
+                    .endAt(scheduledTrigger.getEndAt())
+                    .build();
             scheduler.scheduleQuartzJob(scheduledTrigger.getId(), Scheduler.DEFAULT_GROUP, ScheduledTriggerJob.class, quartzTrigger);
             scheduledTrigger.setQuartzTrigger(quartzTrigger);
             logger.info("Successfully scheduled {}", scheduledTrigger);
@@ -277,6 +289,7 @@ public class TriggerOperator {
 
     /**
      * Checks if a {@code ScheduledTrigger} is scheduled in the scheduler or not
+     *
      * @param scheduledTrigger
      * @return
      * @throws SchedulerException
@@ -291,11 +304,13 @@ public class TriggerOperator {
 
     /**
      * Un-schedules the {@code Trigger}
+     *
      * @param scheduledTrigger
      * @throws SchedulerException
      */
     public void unscheduleTrigger(ScheduledTrigger scheduledTrigger) throws SchedulerException {
-        if (!initialized.get()) throw new SchedulerException("Trigger service is not initialized. initialize() must be called before calling unscheduleTrigger() method");
+        if (!initialized.get())
+            throw new SchedulerException("Trigger service is not initialized. initialize() must be called before calling unscheduleTrigger() method");
         try {
             scheduler.unscheduleQuartzJob(scheduledTrigger.getId(), Scheduler.DEFAULT_GROUP);
             scheduledTrigger.setQuartzTrigger(null);
@@ -307,6 +322,7 @@ public class TriggerOperator {
 
     /**
      * Returns a list of {@code Trigger}s registered with the trigger service for the given triggerGroup
+     *
      * @param triggerGroup
      * @return
      */
@@ -316,6 +332,7 @@ public class TriggerOperator {
 
     /**
      * Returns a list of all the {@code Trigger}s registered with the trigger service
+     *
      * @return
      */
     public List<Trigger> getTriggers() {
@@ -324,6 +341,7 @@ public class TriggerOperator {
 
     /**
      * Executes the {@code Trigger}
+     *
      * @param triggerId
      * @throws Exception
      */
@@ -338,6 +356,7 @@ public class TriggerOperator {
 
     /**
      * Executes the {@code Trigger}
+     *
      * @param trigger
      * @throws Exception
      */

--- a/fenzo-triggers/src/test/groovy/com/netflix/fenzo/triggers/TriggerOperatorSpec.groovy
+++ b/fenzo-triggers/src/test/groovy/com/netflix/fenzo/triggers/TriggerOperatorSpec.groovy
@@ -14,25 +14,40 @@
  * limitations under the License.
  */
 
-package com.netflix.fenzo.triggers.persistence
-import com.netflix.fenzo.triggers.CronTrigger
-import com.netflix.fenzo.triggers.Trigger
-import com.netflix.fenzo.triggers.TriggerOperator
+package com.netflix.fenzo.triggers
+
+import com.netflix.fenzo.triggers.persistence.InMemoryTriggerDao
+import com.netflix.fenzo.triggers.persistence.TriggerDao
+import org.joda.time.DateTime
 import rx.functions.Action1
 import spock.lang.Shared
 import spock.lang.Specification
+
 /**
  *
  * @author sthadeshwar
  */
 class TriggerOperatorSpec extends Specification {
 
-    @Shared TriggerDao triggerDao = new InMemoryTriggerDao()
-    @Shared TriggerOperator triggerOperator = new TriggerOperator(triggerDao, 1)
+    @Shared
+    TriggerDao triggerDao = new InMemoryTriggerDao()
+    @Shared
+    TriggerOperator triggerOperator = new TriggerOperator(triggerDao, 1)
 
     class Data {
         String status
+
         Data(String status) { this.status = status }
+    }
+
+    class Count {
+        int cnt
+        Count(int cnt) { this.cnt = cnt }
+    }
+
+    static class CountAction implements Action1<Count> {
+        @Override
+        void call(Count foo) {foo.cnt = foo.cnt + 1}
     }
 
     static class TestAction implements Action1<Data> {
@@ -88,7 +103,7 @@ class TriggerOperatorSpec extends Specification {
         then:
         enabledTrigger != null
         enabledTrigger.id == disableEnableTrigger.id
-        enabledTrigger.disabled == false
+        !enabledTrigger.disabled
 
         when:
         triggerOperator.execute(enabledTrigger.id)
@@ -110,6 +125,24 @@ class TriggerOperatorSpec extends Specification {
 
         then:
         executedTrigger.data.status == 'executed'
+
+        cleanup:
+        triggerOperator.destroy()
+    }
+
+    void 'test interval trigger'() {
+        setup:
+        triggerOperator.initialize()
+
+        when:
+        def triggerStartTime = DateTime.now().plusSeconds(10)
+        Trigger<Count> scheduledTrigger = new IntervalTrigger<Count>( triggerStartTime.toString() + "/PT10S", 5, "test-trigger", new Count(0), Count.class, CountAction.class);
+        String tid = triggerOperator.registerTrigger("int", scheduledTrigger);
+        Thread.sleep(30 * 1000);
+        Trigger<Count> executedTrigger = triggerOperator.getTrigger(tid);
+
+        then:
+        executedTrigger.data.cnt == 3
 
         cleanup:
         triggerOperator.destroy()


### PR DESCRIPTION
IntervalTrigger specs
1. interval : ISO-8601 format interval spec, could be one of the following
   start-time/end-time
   start-time/duration
2. repeatCount : number of times trigger repeated based on interval specs

ScheduledTrigger to support startAt, endAt so as to work with TriggerBuilder (quartz)
