### PR TITLE
Ming Jin: fix gradle 2.4+ issue of NoClassDefFoundError 'BroadcastDis…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,8 @@ ext.githubProjectName = 'Fenzo'
 buildscript {
     repositories { jcenter() }
     dependencies {
-        classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:2.2.8'
+		classpath 'com.netflix.nebula:gradle-dependency-lock-plugin:4.1.3'
+        classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:3.1.2'
     }
 }
 
@@ -38,7 +39,7 @@ subprojects {
 
     repositories { jcenter() }
 
-    apply plugin: 'dependency-lock'
+	apply plugin: 'nebula.dependency-lock'
     apply plugin: 'java'
     apply plugin: 'groovy'
 


### PR DESCRIPTION
With Gradle 2.9 on Mac, building Fenzo return bellow exception:

```
Caused by: java.lang.NoClassDefFoundError: org/gradle/listener/BroadcastDispatch
	at nebula.plugin.netflixossproject.NetflixOssProjectPlugin.apply(NetflixOssProjectPlugin.groovy:49)
	at nebula.plugin.netflixossproject.NetflixOssProjectPlugin.apply(NetflixOssProjectPlugin.groovy)
	at org.gradle.api.internal.plugins.ImperativeOnlyPluginApplicator.applyImperative(ImperativeOnlyPluginApplicator.java:35)
	at org.gradle.api.internal.plugins.RuleBasedPluginApplicator.applyImperative(RuleBasedPluginApplicator.java:44)
	at org.gradle.api.internal.plugins.DefaultPluginManager.doApply(DefaultPluginManager.java:144)
	at org.gradle.api.internal.plugins.DefaultPluginManager.apply(DefaultPluginManager.java:112)
	at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction.applyType(DefaultObjectConfigurationAction.java:112)
	at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction.access$200(DefaultObjectConfigurationAction.java:35)
	at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction$3.run(DefaultObjectConfigurationAction.java:79)
	at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction.execute(DefaultObjectConfigurationAction.java:135)
	at org.gradle.api.internal.project.AbstractPluginAware.apply(AbstractPluginAware.java:46)
	...
```

The 'netflixoss' plugin needs to be upgraded to '3.1.2' , and the 'dependency-lock' plugin needs to be upgraded as well.