### PR TITLE
Allow tasks to specify assigned resources

### DIFF
--- a/fenzo-core/src/main/java/com/netflix/fenzo/TaskRequest.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/TaskRequest.java
@@ -24,7 +24,7 @@ import java.util.Map;
  */
 public interface TaskRequest {
 
-    public class NamedResourceSetRequest {
+    class NamedResourceSetRequest {
         private final String resName;
         private final String resValue;
         private final int numSets;
@@ -54,54 +54,66 @@ public interface TaskRequest {
         }
     }
 
+    class AssignedResources {
+        private List<PreferentialNamedConsumableResourceSet.ConsumeResult> consumedNamedResources;
+
+        public List<PreferentialNamedConsumableResourceSet.ConsumeResult> getConsumedNamedResources() {
+            return consumedNamedResources;
+        }
+
+        public void setConsumedNamedResources(List<PreferentialNamedConsumableResourceSet.ConsumeResult> consumedNamedResources) {
+            this.consumedNamedResources = consumedNamedResources;
+        }
+    }
+
     /**
      * Get an identifier for this task request.
      *
      * @return a task identifier
      */
-    public String getId();
+    String getId();
 
     /**
      * Get the name of the task group that this task request belongs to.
      *
      * @return the name of the group
      */
-    public String taskGroupName();
+    String taskGroupName();
 
     /**
      * Get the number of CPUs requested by the task.
      *
      * @return how many CPUs the task is requesting
      */
-    public double getCPUs();
+    double getCPUs();
 
     /**
      * Get the amount of memory in MBs requested by the task.
      *
      * @return how many MBs of memory the task is requesting
      */
-    public double getMemory();
+    double getMemory();
 
     /**
      * Get the network bandwidth in Mbps requested by the task.
      *
      * @return how many Mbps of network bandwidth the task is requesting
      */
-    public double getNetworkMbps();
+    double getNetworkMbps();
 
     /**
      * Get the disk space in MBs requested by the task.
      *
      * @return how much disk space in MBs the task is requesting
      */
-    public double getDisk();
+    double getDisk();
 
     /**
      * Get the number of ports requested by the task.
      *
      * @return how many ports the task is requesting
      */
-    public int getPorts();
+    int getPorts();
 
     /**
      * Get the list of custom named resource sets requested by the task.
@@ -116,7 +128,7 @@ public interface TaskRequest {
      *
      * @return a List of hard constraints
      */
-    public List<? extends ConstraintEvaluator> getHardConstraints();
+    List<? extends ConstraintEvaluator> getHardConstraints();
 
     /**
      * Get a list of the soft constraints the task requests. Soft constraints need not be satisfied by a host
@@ -125,5 +137,9 @@ public interface TaskRequest {
      *
      * @return a List of soft constraints
      */
-    public List<? extends VMTaskFitnessCalculator> getSoftConstraints();
+    List<? extends VMTaskFitnessCalculator> getSoftConstraints();
+
+    void setAssignedResources(AssignedResources assignedResources);
+
+    AssignedResources getAssignedResources();
 }

--- a/fenzo-core/src/main/java/com/netflix/fenzo/samples/TaskGenerator.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/samples/TaskGenerator.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A simple task generator to use with {@link SampleFramework}.
@@ -65,6 +66,7 @@ public class TaskGenerator implements Runnable {
 
     private TaskRequest getTaskRequest(final int id) {
         final String taskId = "" + id;
+        final AtomicReference<TaskRequest.AssignedResources> assgndResRef = new AtomicReference<>();
         return new TaskRequest() {
             @Override
             public String getId() {
@@ -109,6 +111,16 @@ public class TaskGenerator implements Runnable {
             @Override
             public List<? extends VMTaskFitnessCalculator> getSoftConstraints() {
                 return null;
+            }
+
+            @Override
+            public void setAssignedResources(AssignedResources assignedResources) {
+                assgndResRef.set(assignedResources);
+            }
+
+            @Override
+            public AssignedResources getAssignedResources() {
+                return assgndResRef.get();
             }
 
             @Override

--- a/fenzo-core/src/test/java/com/netflix/fenzo/RandomTaskGenerator.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/RandomTaskGenerator.java
@@ -57,6 +57,7 @@ public class RandomTaskGenerator {
         private final long runUntilMillis;
         private final long runtimeMillis;
         private String hostname;
+        private AssignedResources assignedResources=null;
         public GeneratedTask(final TaskRequest taskRequest, final long runtimeMillis, final long runUntilMillis) {
             this.taskRequest = taskRequest;
             this.runUntilMillis = runUntilMillis;
@@ -106,6 +107,15 @@ public class RandomTaskGenerator {
         public List<? extends VMTaskFitnessCalculator> getSoftConstraints() {
             return taskRequest.getSoftConstraints();
         }
+        @Override
+        public void setAssignedResources(AssignedResources assignedResources) {
+            this.assignedResources = assignedResources;
+        }
+        @Override
+        public AssignedResources getAssignedResources() {
+            return assignedResources;
+        }
+
         @Override
         public Map<String, NamedResourceSetRequest> getCustomNamedResources() {
             return Collections.emptyMap();

--- a/fenzo-core/src/test/java/com/netflix/fenzo/TaskRequestProvider.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/TaskRequestProvider.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 class TaskRequestProvider {
 
@@ -60,6 +61,7 @@ class TaskRequestProvider {
                                       final Map<String, TaskRequest.NamedResourceSetRequest> resourceSets
     ) {
         final String taskId = ""+id.incrementAndGet();
+        final AtomicReference<TaskRequest.AssignedResources> arRef = new AtomicReference<>();
         return new TaskRequest() {
             @Override
             public String getId() {
@@ -98,6 +100,14 @@ class TaskRequestProvider {
             @Override
             public List<? extends VMTaskFitnessCalculator> getSoftConstraints() {
                 return softConstraints;
+            }
+            @Override
+            public void setAssignedResources(AssignedResources assignedResources) {
+                arRef.set(assignedResources);
+            }
+            @Override
+            public AssignedResources getAssignedResources() {
+                return arRef.get();
             }
             @Override
             public Map<String, NamedResourceSetRequest> getCustomNamedResources() {


### PR DESCRIPTION
Allow tasks to specify assigned resources to track custom defined resources.
For now that includes just the named consumable resource set.