### PR TITLE
Scalar resources

### DIFF
--- a/fenzo-core/src/main/java/com/netflix/fenzo/TaskRequest.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/TaskRequest.java
@@ -116,6 +116,14 @@ public interface TaskRequest {
     int getPorts();
 
     /**
+     * Get the scalar resources being requested by the task.
+     * Although the cpus, memory, networkMbps, and disk are scalar resources, Fenzo currently treats the separately. Use
+     * this scalar requests collection to specify scalar resources other than those four.
+     * @return A {@link Map} of scalar resources requested, with resource name as the key and amount requested as the value.
+     */
+    Map<String, Double> getScalarRequests();
+
+    /**
      * Get the list of custom named resource sets requested by the task.
      *
      * @return List of named resource set requests, or null.

--- a/fenzo-core/src/main/java/com/netflix/fenzo/TaskScheduler.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/TaskScheduler.java
@@ -58,7 +58,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * {@link #getTaskUnAssigner getTaskUnAssigner()} method. These actions make the {@code TaskScheduler} keep
  * track of launched tasks. The {@code TaskScheduler} then makes these tracked tasks available to its
  * scheduling optimization functions.
- * </ol>
+ *
  * Do not call the scheduler concurrently. The scheduler assigns tasks in the order that they are received in a
  * particular list. It checks each task against available resources until it finds a match.
  * <p>
@@ -133,8 +133,8 @@ public class TaskScheduler {
         /**
          * Call this method to set the maximum number of offers to reject within a time period equal to lease expiry
          * seconds, set with {@code leaseOfferExpirySecs()}. Default is 4.
-         * @param maxOffersToReject
-         * @return
+         * @param maxOffersToReject Maximum number of offers to reject.
+         * @return this same {@code Builder}, suitable for further chaining or to build the {@link TaskScheduler}
          */
         public Builder withMaxOffersToReject(int maxOffersToReject) {
             if(!rejectAllExpiredOffers)
@@ -146,7 +146,7 @@ public class TaskScheduler {
          * Indicate that all offers older than the set expiry time must be rejected. By default this is set to false.
          * If false, Fenzo rejects a maximum number of offers set using {@link #withMaxOffersToReject(int)} per each
          * time period spanning the expiry time, set by {@link #withLeaseOfferExpirySecs(long)}.
-         * @return
+         * @return this same {@code Builder}, suitable for further chaining or to build the {@link TaskScheduler}
          */
         public Builder withRejectAllExpiredOffers() {
             this.rejectAllExpiredOffers = true;

--- a/fenzo-core/src/main/java/com/netflix/fenzo/TaskTracker.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/TaskTracker.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * @warn class description missing
+ * Class to keep track of task assignments.
  */
 public class TaskTracker {
 

--- a/fenzo-core/src/main/java/com/netflix/fenzo/VMResource.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/VMResource.java
@@ -28,5 +28,6 @@ public enum VMResource {
     Ports,
     Disk,
     ResourceSet,
-    Fitness
+    Fitness,
+    Other
 }

--- a/fenzo-core/src/main/java/com/netflix/fenzo/VirtualMachineLease.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/VirtualMachineLease.java
@@ -133,4 +133,19 @@ public interface VirtualMachineLease {
      * @return a Map of attribute names to attribute values
      */
     public Map<String, Protos.Attribute> getAttributeMap();
+
+    /**
+     * Get the value of the scalar resource for the given <code>name</code>.
+     * @param name Name of the scalar resource.
+     * @return Value of the requested scalar resource if available, <code>null</code> otherwise.
+     */
+    Double getScalarValue(String name);
+
+    /**
+     * Get a map of all of the scalar resources with resource names as the key and resource value as the value.
+     * Although cpus, memory, networkMbps, and disk are scalar resources, Fenzo currently treats them separately. Use
+     * this scalar values collection to specify scalar resources other than those four.
+     * @return All of the scalar resources available.
+     */
+    Map<String, Double> getScalarValues();
 }

--- a/fenzo-core/src/main/java/com/netflix/fenzo/samples/TaskGenerator.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/samples/TaskGenerator.java
@@ -104,6 +104,11 @@ public class TaskGenerator implements Runnable {
             }
 
             @Override
+            public Map<String, Double> getScalarRequests() {
+                return null;
+            }
+
+            @Override
             public List<? extends ConstraintEvaluator> getHardConstraints() {
                 return null;
             }

--- a/fenzo-core/src/test/java/com/netflix/fenzo/LeaseProvider.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/LeaseProvider.java
@@ -18,11 +18,7 @@ package com.netflix.fenzo;
 
 import org.apache.mesos.Protos;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 class LeaseProvider {
 
@@ -45,8 +41,15 @@ class LeaseProvider {
     static VirtualMachineLease getLeaseOffer(final String hostname, final double cpus, final double memory, final double disk,
                                              final double network, final List<VirtualMachineLease.Range> portRanges,
                                              final Map<String, Protos.Attribute> attributesMap) {
+        return getLeaseOffer(hostname, cpus, memory, disk, network, portRanges, attributesMap, null);
+    }
+
+    static VirtualMachineLease getLeaseOffer(final String hostname, final double cpus, final double memory, final double disk,
+                                             final double network, final List<VirtualMachineLease.Range> portRanges,
+                                             final Map<String, Protos.Attribute> attributesMap, Map<String, Double> scalarResources) {
         final long offeredTime = System.currentTimeMillis();
         final String id = UUID.randomUUID().toString();
+        final Map<String, Double> scalars = scalarResources==null? Collections.<String, Double>emptyMap() : scalarResources;
         return new VirtualMachineLease() {
             @Override
             public String getId() {
@@ -91,6 +94,14 @@ class LeaseProvider {
             @Override
             public Map<String, Protos.Attribute> getAttributeMap() {
                 return attributesMap==null? null : attributesMap;
+            }
+            @Override
+            public Double getScalarValue(String name) {
+                return scalars.get(name);
+            }
+            @Override
+            public Map<String, Double> getScalarValues() {
+                return scalars;
             }
         };
     }

--- a/fenzo-core/src/test/java/com/netflix/fenzo/RandomTaskGenerator.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/RandomTaskGenerator.java
@@ -99,6 +99,12 @@ public class RandomTaskGenerator {
         public int getPorts() {
             return taskRequest.getPorts();
         }
+
+        @Override
+        public Map<String, Double> getScalarRequests() {
+            return null;
+        }
+
         @Override
         public List<? extends ConstraintEvaluator> getHardConstraints() {
             return taskRequest.getHardConstraints();

--- a/fenzo-core/src/test/java/com/netflix/fenzo/ScalarResourceTests.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/ScalarResourceTests.java
@@ -1,0 +1,118 @@
+package com.netflix.fenzo;
+
+import com.netflix.fenzo.functions.Action1;
+import junit.framework.Assert;
+import org.junit.Test;
+
+import java.util.*;
+
+public class ScalarResourceTests {
+
+    private TaskScheduler getScheduler() {
+        return new TaskScheduler.Builder()
+                .withLeaseOfferExpirySecs(1000000)
+                .withLeaseRejectAction(new Action1<VirtualMachineLease>() {
+                    @Override
+                    public void call(VirtualMachineLease virtualMachineLease) {
+                        System.out.println("Rejecting offer on host " + virtualMachineLease.hostname());
+                    }
+                })
+                .build();
+    }
+
+    // Test that asking for a scalar resource gets the task assigned
+    @Test
+    public void testScalar1() throws Exception {
+        final TaskScheduler scheduler = getScheduler();
+        final Map<String, Double> scalars = new HashMap<>();
+        scalars.put("gpu", 1.0);
+        final TaskRequest task = TaskRequestProvider.getTaskRequest(null, 1, 100, 1, 1, 1, null, null, null, scalars);
+        final VirtualMachineLease host1 = LeaseProvider.getLeaseOffer("host1", 4.0, 4000.0, 100, 1024,
+                Collections.singletonList(new VirtualMachineLease.Range(1, 10)), null, scalars);
+        final SchedulingResult result = scheduler.scheduleOnce(Collections.singletonList(task), Collections.singletonList(host1));
+        Assert.assertEquals(0, result.getFailures().size());
+        Assert.assertEquals(1, result.getResultMap().size());
+        Assert.assertEquals(task.getId(), result.getResultMap().values().iterator().next().getTasksAssigned().iterator().next().getRequest().getId());
+    }
+
+    // Test that asking for more than available scalar resources does not get the task assigned
+    @Test
+    public void testInsufficientScalarResources() throws Exception {
+        final TaskScheduler scheduler = getScheduler();
+        final double scalarsOnHost=4.0;
+        final TaskRequest task = TaskRequestProvider.getTaskRequest(null, 1, 100, 1, 1, 1, null, null, null, Collections.singletonMap("gpu", scalarsOnHost+1.0));
+        final VirtualMachineLease host1 = LeaseProvider.getLeaseOffer("host1", 4.0, 4000.0, 100, 1024,
+                Collections.singletonList(new VirtualMachineLease.Range(1, 10)), null, Collections.singletonMap("gpu", scalarsOnHost));
+        final SchedulingResult result = scheduler.scheduleOnce(Collections.singletonList(task), Collections.singletonList(host1));
+        Assert.assertEquals(1, result.getFailures().size());
+        Assert.assertEquals(0, result.getResultMap().size());
+        Assert.assertEquals(VMResource.Other, result.getFailures().values().iterator().next().get(0).getFailures().get(0).getResource());
+        System.out.println(result.getFailures().values().iterator().next().get(0).getFailures().get(0));
+    }
+
+    @Test
+    public void testMultipleTasksScalarRequests() throws Exception {
+        final TaskScheduler scheduler = getScheduler();
+        final double scalarsOnHost = 4.0;
+        final List<TaskRequest> tasks = new ArrayList<>();
+        for (int i = 0; i < scalarsOnHost + 1; i++)
+            tasks.add(TaskRequestProvider.getTaskRequest(null, 1, 100, 1, 1, 1, null, null, null, Collections.singletonMap("gpu", 1.0)));
+        final VirtualMachineLease host1 = LeaseProvider.getLeaseOffer("host1", scalarsOnHost*2.0, scalarsOnHost*2000.0, 100, 1024,
+                Collections.singletonList(new VirtualMachineLease.Range(1, 10)), null, Collections.singletonMap("gpu", scalarsOnHost));
+        final SchedulingResult result = scheduler.scheduleOnce(tasks, Collections.singletonList(host1));
+        Assert.assertEquals(1, result.getFailures().size());
+        Assert.assertEquals(1, result.getResultMap().size());
+        Assert.assertEquals((int)scalarsOnHost, result.getResultMap().values().iterator().next().getTasksAssigned().size());
+        Assert.assertEquals(VMResource.Other, result.getFailures().values().iterator().next().get(0).getFailures().get(0).getResource());
+    }
+
+    @Test
+    public void testScalarRequestsAcrossHosts() throws Exception {
+        final TaskScheduler scheduler = getScheduler();
+        final double scalarsOnHost = 4.0;
+        final List<TaskRequest> tasks = new ArrayList<>();
+        for (int i = 0; i < scalarsOnHost * 2; i++)
+            tasks.add(TaskRequestProvider.getTaskRequest(null, 1, 100, 1, 1, 1, null, null, null, Collections.singletonMap("gpu", 1.0)));
+        final VirtualMachineLease host1 = LeaseProvider.getLeaseOffer("host1", scalarsOnHost, scalarsOnHost*1000.0, 100, 1024,
+                Collections.singletonList(new VirtualMachineLease.Range(1, 10)), null, Collections.singletonMap("gpu", scalarsOnHost));
+        final VirtualMachineLease host2 = LeaseProvider.getLeaseOffer("host2", scalarsOnHost, scalarsOnHost*1000.0, 100, 1024,
+                Collections.singletonList(new VirtualMachineLease.Range(1, 10)), null, Collections.singletonMap("gpu", scalarsOnHost));
+        final SchedulingResult result = scheduler.scheduleOnce(tasks, Arrays.asList(host1, host2));
+        Assert.assertEquals(0, result.getFailures().size());
+        Assert.assertEquals(2, result.getResultMap().size());
+        int tasksAssigned=0;
+        for(VMAssignmentResult r: result.getResultMap().values()) {
+            tasksAssigned += r.getTasksAssigned().size();
+        }
+        Assert.assertEquals(tasks.size(), tasksAssigned);
+    }
+
+    // test allocation of multiple scalar resources
+    @Test
+    public void testMultipleScalarResources() throws Exception {
+        final TaskScheduler scheduler = getScheduler();
+        final double scalars1OnHost = 4.0;
+        final double scalars2OnHost = 2.0;
+        final Map<String, Double> scalarReqs = new HashMap<>();
+        scalarReqs.put("gpu", 1.0);
+        scalarReqs.put("foo", 1.0);
+        final List<TaskRequest> tasks = new ArrayList<>();
+        for(int i=0; i<scalars1OnHost*2; i++)
+            tasks.add(TaskRequestProvider.getTaskRequest(null, 1, 100, 1, 1, 1, null, null, null, scalarReqs));
+        final Map<String, Double> scalarResources = new HashMap<>();
+        scalarResources.put("gpu", scalars1OnHost);
+        scalarResources.put("foo", scalars2OnHost);
+        final VirtualMachineLease host1 = LeaseProvider.getLeaseOffer("host1", scalars1OnHost*2.0, scalars1OnHost*2000.0, 100, 1024,
+                Collections.singletonList(new VirtualMachineLease.Range(1, 10)), null, scalarResources);
+        final VirtualMachineLease host2 = LeaseProvider.getLeaseOffer("host2", scalars1OnHost*2.0, scalars1OnHost*2000.0, 100, 1024,
+                Collections.singletonList(new VirtualMachineLease.Range(1, 10)), null, scalarResources);
+        final SchedulingResult result = scheduler.scheduleOnce(tasks, Arrays.asList(host1, host2));
+        Assert.assertEquals((int)(scalars1OnHost/scalars2OnHost)*2, result.getFailures().size());
+        Assert.assertEquals(2, result.getResultMap().size());
+        int tasksAssigned=0;
+        for(VMAssignmentResult r: result.getResultMap().values()) {
+            tasksAssigned += r.getTasksAssigned().size();
+        }
+        Assert.assertEquals((int)(scalars2OnHost*2.0), tasksAssigned);
+    }
+}

--- a/fenzo-core/src/test/java/com/netflix/fenzo/ScalarResourceTests.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/ScalarResourceTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.fenzo;
 
 import com.netflix.fenzo.functions.Action1;

--- a/fenzo-core/src/test/java/com/netflix/fenzo/TaskRequestProvider.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/TaskRequestProvider.java
@@ -60,6 +60,16 @@ class TaskRequestProvider {
                                       final List<? extends VMTaskFitnessCalculator> softConstraints,
                                       final Map<String, TaskRequest.NamedResourceSetRequest> resourceSets
     ) {
+        return getTaskRequest(grpName, cpus, memory, disk, network, ports, hardConstraints, softConstraints, resourceSets, null);
+    }
+
+    static TaskRequest getTaskRequest(final String grpName, final double cpus, final double memory, final double disk,
+                                      final double network, final int ports,
+                                      final List<? extends ConstraintEvaluator> hardConstraints,
+                                      final List<? extends VMTaskFitnessCalculator> softConstraints,
+                                      final Map<String, TaskRequest.NamedResourceSetRequest> resourceSets,
+                                      final Map<String, Double> scalarRequests
+    ) {
         final String taskId = ""+id.incrementAndGet();
         final AtomicReference<TaskRequest.AssignedResources> arRef = new AtomicReference<>();
         return new TaskRequest() {
@@ -92,6 +102,10 @@ class TaskRequestProvider {
             @Override
             public int getPorts() {
                 return ports;
+            }
+            @Override
+            public Map<String, Double> getScalarRequests() {
+                return scalarRequests;
             }
             @Override
             public List<? extends ConstraintEvaluator> getHardConstraints() {


### PR DESCRIPTION
Add support for any scalar resources to be tracked and assigned. 
The scalar resources CPU, memory, network bandwidth, and disk remain as they are currently, explicitly asked for and assigned. This new addition lets you specify any other scalar resources in a generic way, providing the scalar resource name and a value for the quantity for the resource.
This does require a change to the interfaces TaskRequest and VirtualMachineLease.