### PR TITLE
change signature of TaskSchedulingService.removeTask

### DIFF
--- a/fenzo-core/src/main/java/com/netflix/fenzo/queues/InternalTaskQueue.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/queues/InternalTaskQueue.java
@@ -27,9 +27,8 @@ import java.util.Map;
  * the queue while a scheduling iteration using this queue is in progress. Implementations must handle this. Note that,
  * it may not be sufficient for the implementations to use concurrent versions of collection classes for queue of tasks.
  * The queue must be consistent throughout the scheduling iteration. One recommended way to achieve such consistency is
- * to place the {@link #queueTask(QueuableTask)} and {@link #remove(String, QAttributes)}
- * operations as requests in a holding area within the implementation and return immediately. Later, actually carry
- * them out during the {@link #reset()} method.
+ * to place the {@link #queueTask(QueuableTask)} operations as requests in a holding area within the implementation and
+ * return immediately. Later, actually carry them out during the {@link #reset()} method.
  */
 public interface InternalTaskQueue extends TaskQueue {
     /**
@@ -41,7 +40,7 @@ public interface InternalTaskQueue extends TaskQueue {
      * adding to or removing from the queue.
      * @throws TaskQueueMultiException If any exceptions that may have occurred during resetting the pointer to the head
      * of the queue. Or, this may include exceptions that arose when applying any deferred operations from
-     * {@link #queueTask(QueuableTask)} and {@link #remove(String, QAttributes)} methods.
+     * {@link #queueTask(QueuableTask)} method.
      */
     boolean reset() throws TaskQueueMultiException;
 

--- a/fenzo-core/src/main/java/com/netflix/fenzo/samples/SampleQbasedScheduling.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/samples/SampleQbasedScheduling.java
@@ -78,7 +78,8 @@ public class SampleQbasedScheduling {
                 case TASK_LOST:
                 case TASK_FINISHED:
                     System.out.println("Task status for " + status.getTaskId().getValue() + ": " + status.getState());
-                    schedSvcGetter.get().removeTask(allTasks.get(status.getTaskId().getValue()),
+                    schedSvcGetter.get().removeTask(status.getTaskId().getValue(),
+                            allTasks.get(status.getTaskId().getValue()).getQAttributes(),
                             tasksToHostnameMap.get(status.getTaskId().getValue()));
                     numTasksCompleted.incrementAndGet();
             }

--- a/fenzo-core/src/test/java/com/netflix/fenzo/TaskSchedulingServiceTest.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/TaskSchedulingServiceTest.java
@@ -428,7 +428,7 @@ public class TaskSchedulingServiceTest {
             Assert.fail("Didn't get vm states in time");
         }
         Assert.assertTrue("Did not find task on vm", found.get());
-        schedulingService.removeTask(task, leases.get(0).hostname());
+        schedulingService.removeTask(task.getId(), task.getQAttributes(), leases.get(0).hostname());
         found.set(false);
         final CountDownLatch latch3 = new CountDownLatch(1);
         schedulingService.requestVmCurrentStates(new Action1<List<VirtualMachineCurrentState>>() {


### PR DESCRIPTION
New signature now takes taskId and qAttributes instead of QueuableTask object.