### PR TITLE
Autoscale chgs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ allprojects {
     apply plugin: 'idea'
     
     group = 'com.netflix.fenzo'
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 }
 
 subprojects {

--- a/fenzo-core/src/main/java/com/netflix/fenzo/AutoScaleRule.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/AutoScaleRule.java
@@ -30,7 +30,7 @@ public interface AutoScaleRule {
      * @return the value of the designated host attribute, which is the name of the autoscaling group this rule
      *         applies to
      */
-    public String getRuleName();
+    String getRuleName();
 
     /**
      * Returns the minimum number of hosts, in the autoscale group this rule applies to, that Fenzo is to keep
@@ -39,7 +39,17 @@ public interface AutoScaleRule {
      *
      * @return the minimum number of idle hosts to maintain in this autoscale group
      */
-    public int getMinIdleHostsToKeep();
+    int getMinIdleHostsToKeep();
+
+    /**
+     * Returns the minimum number of hosts to expect in the autoscale group for this rule. Fenzo will not invoke
+     * scale down actions that will make the group size to go below this minimum size. A value of {@code 0} effectively
+     * disables this function.
+     * @return The minimum number of hosts to expect in the group, even if idle.
+     */
+    default int getMinSize() {
+        return 0;
+    }
 
     /**
      * Returns the maximum number of hosts, in the autoscale group this rule applies to, that Fenzo is to keep
@@ -48,7 +58,17 @@ public interface AutoScaleRule {
      *
      * @return the maximum number of idle hosts to maintain in this autoscale group
      */
-    public int getMaxIdleHostsToKeep();
+    int getMaxIdleHostsToKeep();
+
+    /**
+     * Returns the maximum number of hosts to expect in the autoscale group for this rule. Fenzo will not invoke
+     * scale up actions that could make the group size higher than this value. A value of {@link Integer#MAX_VALUE}
+     * effectively disables this function.
+     * @return The maximum number of hosts to expect in this group, even if no idle hosts remain.
+     */
+    default int getMaxSize() {
+        return Integer.MAX_VALUE;
+    }
 
     /**
      * Returns the amount of time to wait from the beginning of a scale up or scale down operation before
@@ -57,7 +77,7 @@ public interface AutoScaleRule {
      *
      * @return the cool down time, in seconds
      */
-    public long getCoolDownSecs();
+    long getCoolDownSecs();
 
     /**
      * Determines whether a host has too few resources to be considered an idle but potentially useful host.
@@ -67,5 +87,5 @@ public interface AutoScaleRule {
      * @param lease the lease object that representes the host
      * @return {@code true} if the idle machine has too few resources to count as idle, {@code false} otherwise
      */
-    public boolean idleMachineTooSmall(VirtualMachineLease lease);
+    boolean idleMachineTooSmall(VirtualMachineLease lease);
 }

--- a/fenzo-core/src/main/java/com/netflix/fenzo/TaskScheduler.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/TaskScheduler.java
@@ -412,13 +412,14 @@ public class TaskScheduler {
         resAllocsEvaluator = new ResAllocsEvaluater(taskTracker, builder.resAllocs);
         assignableVMs = new AssignableVMs(taskTracker, builder.leaseRejectAction,
                 builder.leaseOfferExpirySecs, builder.maxOffersToReject, builder.autoScaleByAttributeName,
-                builder.singleOfferMode);
+                builder.singleOfferMode, builder.autoScaleByAttributeName);
         if(builder.autoScaleByAttributeName != null && !builder.autoScaleByAttributeName.isEmpty()) {
 
             autoScaler = new AutoScaler(builder.autoScaleByAttributeName, builder.autoScalerMapHostnameAttributeName,
                     builder.autoScaleDownBalancedByAttributeName,
                     builder.autoScaleRules, assignableVMs, null,
-                    builder.disableShortfallEvaluation, assignableVMs.getActiveVmGroups());
+                    builder.disableShortfallEvaluation, assignableVMs.getActiveVmGroups(),
+                    assignableVMs.getVmCollection());
             if(builder.autoscalerCallback != null)
                 autoScaler.setCallback(builder.autoscalerCallback);
             if(builder.delayAutoscaleDownBySecs > 0L)

--- a/fenzo-core/src/main/java/com/netflix/fenzo/VMCollection.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/VMCollection.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.fenzo;
+
+import com.netflix.fenzo.functions.Func1;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+class VMCollection {
+    private static final String defaultGroupName = "DEFAULT";
+    private final ConcurrentMap<String, ConcurrentMap<String, AssignableVirtualMachine>> vms;
+    private final Func1<String, AssignableVirtualMachine> newVmCreator;
+    private final String groupingAttrName;
+
+    VMCollection(Func1<String, AssignableVirtualMachine> func1, String groupingAttrName) {
+        vms = new ConcurrentHashMap<>();
+        this.newVmCreator = func1;
+        this.groupingAttrName = groupingAttrName;
+    }
+
+    Collection<AssignableVirtualMachine> getAllVMs() {
+        List<AssignableVirtualMachine> result = new LinkedList<>();
+        vms.values().forEach(m -> m.values().forEach(result::add));
+        return result;
+    }
+
+    Collection<String> getGroups() {
+        return Collections.unmodifiableCollection(vms.keySet());
+    }
+
+    Collection<AssignableVirtualMachine> getVMs(String group) {
+        return Collections.unmodifiableCollection(vms.get(group).values());
+    }
+
+    Optional<AssignableVirtualMachine> getVmByName(String name) {
+        return vms.values().stream()
+                .flatMap(
+                        (Function<ConcurrentMap<String, AssignableVirtualMachine>, Stream<AssignableVirtualMachine>>) m
+                                -> m.values().stream()
+                )
+                .filter(avm -> name.equals(avm.getHostname()))
+                .findFirst();
+    }
+
+    AssignableVirtualMachine create(String host) {
+        return create(host, defaultGroupName);
+    }
+
+    AssignableVirtualMachine create(String host, String group) {
+        vms.putIfAbsent(group, new ConcurrentHashMap<>());
+        AssignableVirtualMachine prev = null;
+        if (!defaultGroupName.equals(group)) {
+            if (vms.get(defaultGroupName) != null)
+                prev = vms.get(defaultGroupName).remove(host);
+        }
+        vms.get(group).putIfAbsent(host, prev == null? newVmCreator.call(host) : prev);
+        return vms.get(group).get(host);
+    }
+
+    AssignableVirtualMachine getOrCreate(String host) {
+        return getOrCreate(host, defaultGroupName);
+    }
+
+    AssignableVirtualMachine getOrCreate(String host, String group) {
+        vms.putIfAbsent(group, new ConcurrentHashMap<>());
+        final AssignableVirtualMachine avm = vms.get(group).get(host);
+        if (avm != null)
+            return avm;
+        return create(host, group);
+    }
+
+    boolean addLease(VirtualMachineLease l) {
+        String group = l.getAttributeMap() == null? null :
+                l.getAttributeMap().get(groupingAttrName) == null?
+                        null :
+                        l.getAttributeMap().get(groupingAttrName).getText().getValue();
+        if (group == null)
+            group = defaultGroupName;
+        final AssignableVirtualMachine avm = getOrCreate(l.hostname(), group);
+        return avm.addLease(l);
+    }
+
+    public int size() {
+        final Optional<Integer> size = vms.values().stream().map(Map::size).reduce((i1, i2) -> i1 + i2);
+        return size.isPresent()? size.get() : 0;
+    }
+
+    public int size(String group) {
+        final ConcurrentMap<String, AssignableVirtualMachine> m = vms.get(group);
+        return m == null? 0 : m.size();
+    }
+
+    public AssignableVirtualMachine remove(AssignableVirtualMachine avm) {
+        final String group = avm.getAttrValue(groupingAttrName);
+        AssignableVirtualMachine removed = null;
+        if (group != null) {
+            final ConcurrentMap<String, AssignableVirtualMachine> m = vms.get(group);
+            if (m != null) {
+                removed = m.remove(avm.getHostname());
+            }
+        }
+        if (removed != null)
+            return removed;
+        final ConcurrentMap<String, AssignableVirtualMachine> m = vms.get(defaultGroupName);
+        if (m != null)
+            m.remove(avm.getHostname());
+        return null;
+    }
+}

--- a/fenzo-core/src/main/java/com/netflix/fenzo/VMCollection.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/VMCollection.java
@@ -76,10 +76,13 @@ class VMCollection {
     }
 
     AssignableVirtualMachine getOrCreate(String host) {
-        return getOrCreate(host, defaultGroupName);
+        final Optional<AssignableVirtualMachine> vmByName = getVmByName(host);
+        if (vmByName.isPresent())
+            return vmByName.get();
+        return create(host, defaultGroupName);
     }
 
-    AssignableVirtualMachine getOrCreate(String host, String group) {
+    private AssignableVirtualMachine getOrCreate(String host, String group) {
         vms.putIfAbsent(group, new ConcurrentHashMap<>());
         final AssignableVirtualMachine avm = vms.get(group).get(host);
         if (avm != null)

--- a/fenzo-core/src/test/java/com/netflix/fenzo/AutoScaleRuleProvider.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/AutoScaleRuleProvider.java
@@ -47,4 +47,74 @@ public class AutoScaleRuleProvider {
             }
         };
     }
+
+    static AutoScaleRule createWithMinSize(final String name, final int min, final int max, final long coolDownSecs,
+                                           final double cpuTooSmall, final double memoryTooSmall, int minSize) {
+        return new AutoScaleRule() {
+            @Override
+            public String getRuleName() {
+                return name;
+            }
+
+            @Override
+            public int getMinIdleHostsToKeep() {
+                return min;
+            }
+
+            @Override
+            public int getMaxIdleHostsToKeep() {
+                return max;
+            }
+
+            @Override
+            public long getCoolDownSecs() {
+                return coolDownSecs;
+            }
+
+            @Override
+            public boolean idleMachineTooSmall(VirtualMachineLease lease) {
+                return (lease.cpuCores()<cpuTooSmall || lease.memoryMB()<memoryTooSmall);
+            }
+
+            @Override
+            public int getMinSize() {
+                return minSize;
+            }
+        };
+    }
+
+    static AutoScaleRule createWithMaxSize(final String name, final int min, final int max, final long coolDownSecs,
+                                           final double cpuTooSmall, final double memoryTooSmall, int maxSize) {
+        return new AutoScaleRule() {
+            @Override
+            public String getRuleName() {
+                return name;
+            }
+
+            @Override
+            public int getMinIdleHostsToKeep() {
+                return min;
+            }
+
+            @Override
+            public int getMaxIdleHostsToKeep() {
+                return max;
+            }
+
+            @Override
+            public long getCoolDownSecs() {
+                return coolDownSecs;
+            }
+
+            @Override
+            public boolean idleMachineTooSmall(VirtualMachineLease lease) {
+                return (lease.cpuCores()<cpuTooSmall || lease.memoryMB()<memoryTooSmall);
+            }
+
+            @Override
+            public int getMaxSize() {
+                return maxSize;
+            }
+        };
+    }
 }

--- a/fenzo-core/src/test/java/com/netflix/fenzo/AutoScalerTest.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/AutoScalerTest.java
@@ -490,6 +490,13 @@ public class AutoScalerTest {
             Thread.sleep(1000);
         }
         Assert.assertEquals(0, latch.getCount());
+        final List<VirtualMachineCurrentState> vmCurrentStates = scheduler.getVmCurrentStates();
+        long now = System.currentTimeMillis();
+        for (VirtualMachineCurrentState s: vmCurrentStates) {
+            if (s.getDisabledUntil() > 0)
+                System.out.println("********** " + s.getHostname() + " disabled for " + (s.getDisabledUntil() - now) +
+                        " mSecs");
+        }
         // remove any existing leases in scheduler
         // now generate offers for hosts that were scale down and ensure they don't get used
         for(String hostname: scaleDownHostsRef.get()) {

--- a/fenzo-core/src/test/java/com/netflix/fenzo/LeaseProvider.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/LeaseProvider.java
@@ -188,14 +188,17 @@ class LeaseProvider {
     static VirtualMachineLease getConsumedLease(VMAssignmentResult result) {
         double cpus=0.0;
         double memory=0.0;
+        double network = 0.0;
         List<Integer> ports = new ArrayList<>();
         for(TaskAssignmentResult r: result.getTasksAssigned()) {
             cpus += r.getRequest().getCPUs();
             memory += r.getRequest().getMemory();
+            network += r.getRequest().getNetworkMbps();
             ports.addAll(r.getAssignedPorts());
         }
         double totalCpus=0.0;
         double totalMem=0.0;
+        double totalNetwork=0.0;
         List<VirtualMachineLease.Range> totPortRanges = new ArrayList<>();
         String hostname="";
         Map<String, Protos.Attribute> attributes = null;
@@ -204,11 +207,12 @@ class LeaseProvider {
             attributes = l.getAttributeMap();
             totalCpus += l.cpuCores();
             totalMem += l.memoryMB();
+            totalNetwork += l.networkMbps();
             totPortRanges.addAll(l.portRanges());
         }
         for(Integer port: ports)
             totPortRanges = getRangesAfterConsuming(totPortRanges, port);
-        return getLeaseOffer(hostname, totalCpus-cpus, totalMem-memory, 0.0, totPortRanges, attributes);
+        return getLeaseOffer(hostname, totalCpus-cpus, totalMem-memory, totalNetwork-network, totPortRanges, attributes);
     }
 
     static VirtualMachineLease getConsumedLease(VirtualMachineLease orig, double consumedCpu, double consumedMemory, List<Integer> consumedPorts) {

--- a/fenzo-core/src/test/java/com/netflix/fenzo/ResourceSetsTests.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/ResourceSetsTests.java
@@ -475,6 +475,7 @@ public class ResourceSetsTests {
             taskScheduler.getTaskAssigner().call(r.getRequest(), r.getHostname());
             taskId = r.getTaskId();
         }
+        Assert.assertEquals(tasks.size(), tasksAssigned);
         tasks.clear();
         tasks.add(TaskRequestProvider.getTaskRequest(
                 "grp", 0.1, 100, 0, 0, 0, null, null, Collections.singletonMap(sr2.getResName(), sr2)));


### PR DESCRIPTION
- Move to Java 8 compatibility
- Introduce minSize and maxSize as absolute limits for cluster autoscaling
- VMs are now held internally grouped by the attribute value used for cluster autoscaling