### PR TITLE
Optional task to autoscale group name for shortfall based scale up

### DIFF
--- a/fenzo-core/src/main/java/com/netflix/fenzo/TaskScheduler.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/TaskScheduler.java
@@ -16,6 +16,7 @@
 
 package com.netflix.fenzo;
 
+import com.netflix.fenzo.queues.QueuableTask;
 import com.netflix.fenzo.sla.ResAllocs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -546,6 +547,11 @@ public class TaskScheduler {
 
     /* package */ void setUsingSchedulingService(boolean b) {
         usingSchedulingService = b;
+    }
+
+    /* package */ void setTaskToClusterAutoScalerMapGetter(Func1<QueuableTask, List<String>> getter) {
+        if (autoScaler != null)
+            autoScaler.setTaskToClustersGetter(getter);
     }
 
     /**

--- a/fenzo-core/src/test/java/com/netflix/fenzo/OfferRejectionsTest.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/OfferRejectionsTest.java
@@ -235,12 +235,9 @@ public class OfferRejectionsTest {
         final int leaseExpirySecs=2;
         final Set<String> hostsRejectedFrom = new HashSet<>();
         final TaskScheduler scheduler = new TaskScheduler.Builder()
-                .withLeaseRejectAction(new Action1<VirtualMachineLease>() {
-                    @Override
-                    public void call(VirtualMachineLease virtualMachineLease) {
-                        expireCount.incrementAndGet();
-                        hostsRejectedFrom.add(virtualMachineLease.hostname());
-                    }
+                .withLeaseRejectAction(virtualMachineLease -> {
+                    expireCount.incrementAndGet();
+                    hostsRejectedFrom.add(virtualMachineLease.hostname());
                 })
                 .withLeaseOfferExpirySecs(leaseExpirySecs)
                 .withMaxOffersToReject(1)


### PR DESCRIPTION
Allow optional mapping of tasks to autoscaling group names to optimize scale up trigger for shortfall based scale up