### PR TITLE
Fix inactive VMs purging

### DIFF
--- a/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVMs.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVMs.java
@@ -298,14 +298,16 @@ class AssignableVMs {
         return vmCollection.size();
     }
 
-    void purgeInactiveVMs() {
+    void purgeInactiveVMs(Set<String> excludeVms) {
         for(AssignableVirtualMachine avm: vmCollection.getAllVMs()) {
             if(avm != null) {
-                if(!avm.isActive()) {
-                    vmCollection.remove(avm);
-                    if(avm.getCurrVMId() != null)
-                        vmIdToHostnameMap.remove(avm.getCurrVMId(), avm.getHostname());
-                    logger.info("Removed inactive host " + avm.getHostname());
+                if (!excludeVms.contains(avm.getHostname())) {
+                    if (!avm.isActive()) {
+                        vmCollection.remove(avm);
+                        if (avm.getCurrVMId() != null)
+                            vmIdToHostnameMap.remove(avm.getCurrVMId(), avm.getHostname());
+                        logger.info("Removed inactive host " + avm.getHostname());
+                    }
                 }
             }
         }

--- a/fenzo-core/src/main/java/com/netflix/fenzo/TaskScheduler.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/TaskScheduler.java
@@ -644,7 +644,11 @@ public class TaskScheduler {
             if((lastVMPurgeAt + purgeVMsIntervalSecs*1000) < System.currentTimeMillis()) {
                 lastVMPurgeAt = System.currentTimeMillis();
                 logger.info("Purging inactive VMs");
-                assignableVMs.purgeInactiveVMs();
+                assignableVMs.purgeInactiveVMs( // explicitly exclude VMs that have assignments
+                        schedulingResult.getResultMap() == null?
+                                Collections.emptySet() :
+                                new HashSet<>(schedulingResult.getResultMap().keySet())
+                );
             }
             schedulingResult.setRuntime(System.currentTimeMillis() - start);
             return schedulingResult;


### PR DESCRIPTION
explicitly exclude VMs that had resources assigned in the iteration when purging inactive VMs