### PR TITLE
Build broken under Gradle 3.4.1 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,14 @@
 ext.githubProjectName = 'Fenzo'
 
 buildscript {
-    repositories { jcenter() }
+    repositories {
+        jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
     dependencies {
-        classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:3.2.3'
+        classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:3.5.2'
     }
 }
 


### PR DESCRIPTION
Hi all,
After I'd checked out this repo I tried a `gradle build` which finally failed with this error message:
```
FAILURE: Build failed with an exception.

* Where:
Build file '/home/patrick/git/Fenzo-Fork/build.gradle' line: 27

* What went wrong:
A problem occurred evaluating root project 'fenzo'.
> org/gradle/api/internal/project/AbstractProject
```

Running `gradle build --stacktrace` offered a more precise hint on the root cause:

```
java.lang.ClassNotFoundException: org.gradle.api.internal.project.AbstractProject
```

#### My environment:
* __OS:__ Ubuntu 16.04
* __JDK:__ OpenJDK version 1.8.0_121
* __Gradle version:__ 3.4.1 (Revision: 9eb76efdd3d034dc506c719dac2955efb5ff9a93)

#### What did I do?
I started with bringing the version of `com.netflix.nebula:gradle-netflixoss-project-plugin` up to 3.5.2  (see [build.gradle](https://github.com/PaddySmalls/Fenzo/blob/build_fix/build.gradle)). Then, I tried another `gradle build` to see the effect, ending up with this message:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'fenzo'.
> Could not resolve all dependencies for configuration ':classpath'.
   > Could not find gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.13.1.
     Searched in the following locations:
         https://jcenter.bintray.com/gradle/plugin/nl/javadude/gradle/plugins/license-gradle-plugin/0.13.1/license-gradle-plugin-0.13.1.pom
         https://jcenter.bintray.com/gradle/plugin/nl/javadude/gradle/plugins/license-gradle-plugin/0.13.1/license-gradle-plugin-0.13.1.jar
     Required by:
         project : > com.netflix.nebula:gradle-netflixoss-project-plugin:3.5.2

```  

Finally, checking out the [license-gradle-plugin](https://github.com/hierynomus/license-gradle-plugin) repo brought me on the right track: After adding Maven to the project's repositories, the build succeeded:

```
buildscript {
  repositories {
    maven {
            url "https://plugins.gradle.org/m2/"
        }
       ...
  }
...
}
```

```
$ gradle build -x test

Inferred project: fenzo, version: 0.14.0-SNAPSHOT
Publication nebula not found in project :.
Publication named 'nebula' does not exist for project ':' in task ':artifactoryPublish'.
:compileJava NO-SOURCE
:processResources NO-SOURCE
:classes UP-TO-DATE
:writeManifestProperties UP-TO-DATE
:jar UP-TO-DATE
:assemble UP-TO-DATE
:check
:fenzo-core:compileJava
dependencies.lock is using a deprecated lock format. Support for this format may be removed in future versions.
:fenzo-core:compileJava UP-TO-DATE
:fenzo-core:compileGroovy NO-SOURCE
:fenzo-core:processResources NO-SOURCE
:fenzo-core:classes UP-TO-DATE
:fenzo-core:writeManifestProperties UP-TO-DATE
:fenzo-core:jar UP-TO-DATE
:fenzo-core:assemble UP-TO-DATE
:fenzo-triggers:compileJava
dependencies.lock is using a deprecated lock format. Support for this format may be removed in future versions.
:fenzo-triggers:compileJava UP-TO-DATE
:fenzo-triggers:compileGroovy NO-SOURCE
:fenzo-triggers:processResources NO-SOURCE
:fenzo-triggers:classes UP-TO-DATE
:fenzo-triggers:writeManifestProperties UP-TO-DATE
:fenzo-triggers:jar UP-TO-DATE
:fenzo-triggers:assemble UP-TO-DATE
:collectNetflixOSS
:build
:fenzo-core:writeLicenseHeader
:fenzo-core:licenseMain UP-TO-DATE
:fenzo-core:license UP-TO-DATE
:fenzo-core:check
:fenzo-core:build
:fenzo-triggers:writeLicenseHeader
:fenzo-triggers:licenseMain UP-TO-DATE
:fenzo-triggers:license UP-TO-DATE
:fenzo-triggers:check
:fenzo-triggers:build

BUILD SUCCESSFUL

```
Thanks! :)

Cheers,
Patrick