### PR TITLE
Don't call lease reject action on pseudo VMs

### DIFF
--- a/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVMs.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVMs.java
@@ -116,7 +116,7 @@ class AssignableVMs {
                 for (String h: entry.getValue()) {
                     final AssignableVirtualMachine avm = vmCollection.unsafeRemoveVm(h, entry.getKey());
                     if (avm != null)
-                        avm.removeExpiredLeases(true);
+                        avm.removeExpiredLeases(true, false);
                 }
             }
         }

--- a/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVirtualMachine.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVirtualMachine.java
@@ -331,6 +331,10 @@ class AssignableVirtualMachine implements Comparable<AssignableVirtualMachine>{
     }
 
     void removeExpiredLeases(boolean all) {
+        removeExpiredLeases(all, true);
+    }
+
+    void removeExpiredLeases(boolean all, boolean doRejectCallback) {
         @SuppressWarnings("MismatchedQueryAndUpdateOfCollection") Set<String> leasesToExpireIds = new HashSet<>();
         leasesToExpire.drainTo(leasesToExpireIds);
         Iterator<Map.Entry<String,VirtualMachineLease>> iterator = leasesMap.entrySet().iterator();
@@ -342,7 +346,8 @@ class AssignableVirtualMachine implements Comparable<AssignableVirtualMachine>{
                 if(expireAll) {
                     if(logger.isDebugEnabled())
                         logger.debug(hostname + ": expiring lease offer id " + l.getId());
-                    leaseRejectAction.call(l);
+                    if (doRejectCallback)
+                        leaseRejectAction.call(l);
                 }
                 iterator.remove();
             }

--- a/fenzo-core/src/main/java/com/netflix/fenzo/BaseShortfallEvaluator.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/BaseShortfallEvaluator.java
@@ -43,7 +43,7 @@ abstract class BaseShortfallEvaluator implements ShortfallEvaluator {
     }
 
     @Override
-    public abstract Map<String, Integer> getShortfall(Set<String> attrKeys, Set<TaskRequest> failures, AutoScaleRules autoScaleRules);
+    public abstract Map<String, Integer> getShortfall(Set<String> vmGroupNames, Set<TaskRequest> failures, AutoScaleRules autoScaleRules);
 
     @Override
     public void setTaskSchedulingService(TaskSchedulingService schedulingService) {

--- a/fenzo-core/src/main/java/com/netflix/fenzo/InternalVMCloner.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/InternalVMCloner.java
@@ -152,13 +152,19 @@ import java.util.Map;
         };
     }
 
-    /* package */ VirtualMachineLease cloneLease(VirtualMachineLease lease, String hostname, long now) {
+    /* package */ VirtualMachineLease cloneLease(VirtualMachineLease lease, final String hostname, long now) {
         final List<VirtualMachineLease.Range> ports = new LinkedList<>();
         final List<VirtualMachineLease.Range> ranges = lease.portRanges();
         if (ranges != null && !ranges.isEmpty()) {
             for (VirtualMachineLease.Range r: ranges)
                 ports.add(new VirtualMachineLease.Range(r.getBeg(), r.getEnd()));
         }
+        final double cpus = lease.cpuCores();
+        final double memory = lease.memoryMB();
+        final double network = lease.networkMbps();
+        final double disk = lease.diskMB();
+        final Map<String, Protos.Attribute> attributes = new HashMap<>(lease.getAttributeMap());
+        final Map<String, Double> scalarValues = new HashMap<>(lease.getScalarValues());
         return new VirtualMachineLease() {
             @Override
             public String getId() {
@@ -182,22 +188,22 @@ import java.util.Map;
 
             @Override
             public double cpuCores() {
-                return lease.cpuCores();
+                return cpus;
             }
 
             @Override
             public double memoryMB() {
-                return lease.memoryMB();
+                return memory;
             }
 
             @Override
             public double networkMbps() {
-                return lease.networkMbps();
+                return network;
             }
 
             @Override
             public double diskMB() {
-                return lease.diskMB();
+                return disk;
             }
 
             @Override
@@ -212,17 +218,17 @@ import java.util.Map;
 
             @Override
             public Map<String, Protos.Attribute> getAttributeMap() {
-                return lease.getAttributeMap();
+                return attributes;
             }
 
             @Override
             public Double getScalarValue(String name) {
-                return lease.getScalarValue(name);
+                return scalarValues.get(name);
             }
 
             @Override
             public Map<String, Double> getScalarValues() {
-                return lease.getScalarValues();
+                return scalarValues;
             }
         };
     }

--- a/fenzo-core/src/main/java/com/netflix/fenzo/NaiveShortfallEvaluator.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/NaiveShortfallEvaluator.java
@@ -28,7 +28,7 @@ import java.util.*;
 class NaiveShortfallEvaluator extends BaseShortfallEvaluator {
 
     @Override
-    public Map<String, Integer> getShortfall(Set<String> attrKeys, Set<TaskRequest> failures, AutoScaleRules autoScaleRules) {
+    public Map<String, Integer> getShortfall(Set<String> vmGroupNames, Set<TaskRequest> failures, AutoScaleRules autoScaleRules) {
         // A naive approach to figuring out shortfall of hosts to satisfy the tasks that failed assignments is,
         // strictly speaking, not possible by just attempting to add up required resources for the tasks and then mapping
         // that to the number of hosts required to satisfy that many resources. Several things can make that evaluation
@@ -55,9 +55,9 @@ class NaiveShortfallEvaluator extends BaseShortfallEvaluator {
         // implementations that have ordering semantics other than FIFO. So, we maintain the list of tasks with a
         // timeout and remove it from there so we catch this scenario and ask for the resources again for that task.
 
-        if (attrKeys != null && failures != null && !failures.isEmpty()) {
+        if (vmGroupNames != null && failures != null && !failures.isEmpty()) {
             reset();
-            return adjustAgentScaleUp(fillShortfallMap(attrKeys, filterFailedTasks(failures)), autoScaleRules);
+            return adjustAgentScaleUp(fillShortfallMap(vmGroupNames, filterFailedTasks(failures)), autoScaleRules);
         }
         else
             return Collections.emptyMap();

--- a/fenzo-core/src/main/java/com/netflix/fenzo/OptimizingShortfallEvaluator.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/OptimizingShortfallEvaluator.java
@@ -50,12 +50,12 @@ import java.util.Set;
 class OptimizingShortfallEvaluator extends BaseShortfallEvaluator {
 
     @Override
-    public Map<String, Integer> getShortfall(Set<String> attrKeys, Set<TaskRequest> failures, AutoScaleRules autoScaleRules) {
+    public Map<String, Integer> getShortfall(Set<String> vmGroupNames, Set<TaskRequest> failures, AutoScaleRules autoScaleRules) {
         if (schedulingService == null || failures == null || failures.isEmpty())
             return Collections.emptyMap();
 
         final List<TaskRequest> filteredTasks = filterFailedTasks(failures);
-        final Map<String, Integer> shortfallTasksPerGroup = fillShortfallMap(attrKeys, filteredTasks);
+        final Map<String, Integer> shortfallTasksPerGroup = fillShortfallMap(vmGroupNames, filteredTasks);
         if (shortfallTasksPerGroup.isEmpty())
             return Collections.emptyMap();
 

--- a/fenzo-core/src/main/java/com/netflix/fenzo/ShortfallEvaluator.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/ShortfallEvaluator.java
@@ -27,7 +27,15 @@ import java.util.Set;
 
     void setTaskToClustersGetter(Func1<QueuableTask, List<String>> getter);
 
-    Map<String, Integer> getShortfall(Set<String> attrKeys, Set<TaskRequest> failures, AutoScaleRules autoScaleRules);
+    /**
+     * Get number of VMs of shortfall for each VM Group for the given VM Group names and set of failed tasks.
+     * @param vmGroupNames VM Group names for which autoscale rules are setup, same as the autoscale rule name.
+     * @param failures The tasks that failed assignment due to which VM shortfall must be evaluated.
+     * @param autoScaleRules The current set of autoscale rules.
+     * @return A map with keys containing VM group names (same as autoscale rule names) and values containing the
+     *         number of VMs that may be added to address the shortfall.
+     */
+    Map<String, Integer> getShortfall(Set<String> vmGroupNames, Set<TaskRequest> failures, AutoScaleRules autoScaleRules);
 
     void setTaskSchedulingService(TaskSchedulingService schedulingService);
 }

--- a/fenzo-core/src/main/java/com/netflix/fenzo/VMCollection.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/VMCollection.java
@@ -17,6 +17,8 @@
 package com.netflix.fenzo;
 
 import com.netflix.fenzo.functions.Func1;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -26,6 +28,7 @@ import java.util.stream.Stream;
 
 class VMCollection {
     private static final String defaultGroupName = "DEFAULT";
+    private static final Logger logger = LoggerFactory.getLogger(VMCollection.class);
     private final ConcurrentMap<String, ConcurrentMap<String, AssignableVirtualMachine>> vms;
     private final Func1<String, AssignableVirtualMachine> newVmCreator;
     private final String groupingAttrName;
@@ -75,7 +78,7 @@ class VMCollection {
                 final AutoScaleRule rule = ruleGetter.call(g);
                 if (rule != null) {
                     int max = rule.getMaxSize();
-                    if (max < Integer.MAX_VALUE && n > (max + map.size()))
+                    if (max < Integer.MAX_VALUE && n > (max - map.size()))
                         n = max - map.size();
                 }
                 for (int i = 0; i < n; i++) {
@@ -83,7 +86,7 @@ class VMCollection {
                     try {
                         addLease(vmCloner.cloneLease(lease, hostname, now));
                     } catch (Exception e) {
-                        e.printStackTrace();
+                        logger.error("Unexpected error creating pseudo leases", e);
                     }
                     hostnames.add(hostname);
                 }

--- a/fenzo-core/src/test/java/com/netflix/fenzo/OfferRejectionsTest.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/OfferRejectionsTest.java
@@ -250,7 +250,7 @@ public class OfferRejectionsTest {
         // add the same leases with same hostnames twice again, so there are 3 offers for each of the nHosts.
         leases.addAll(LeaseProvider.getLeases(nhosts, 4, 4000, 1, 10));
         leases.addAll(LeaseProvider.getLeases(nhosts, 4, 4000, 1, 10));
-        for (int i=0; i<leaseExpirySecs+1 && !gotReject.get(); i++) {
+        for (int i=0; i<leaseExpirySecs+2 && !gotReject.get(); i++) {
             scheduler.scheduleOnce(Collections.<TaskRequest>emptyList(), leases);
             leases.clear();
             Thread.sleep(1000);

--- a/fenzo-core/src/test/java/com/netflix/fenzo/VMCollectionTest.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/VMCollectionTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.fenzo;
+
+import com.netflix.fenzo.functions.Action1;
+import org.apache.mesos.Protos;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.junit.Assert.*;
+
+public class VMCollectionTest {
+
+    private final Map<String, Protos.Attribute> attributes1 = new HashMap<>();
+    private final List<VirtualMachineLease.Range> ports = new ArrayList<>();
+    private final String attributeVal1 = "4cores";
+
+    @Before
+    public void setUp() throws Exception {
+        Protos.Attribute attribute = Protos.Attribute.newBuilder().setName(AutoScalerTest.hostAttrName)
+                .setType(Protos.Value.Type.TEXT)
+                .setText(Protos.Value.Text.newBuilder().setValue(attributeVal1)).build();
+        attributes1.put(AutoScalerTest.hostAttrName, attribute);
+        ports.add(new VirtualMachineLease.Range(1, 100));
+    }
+
+    @Test
+    public void clonePseudoVMsForGroups() throws Exception {
+        AutoScaleRule rule = getAutoScaleRule(attributeVal1, 4);
+        Action1<VirtualMachineLease> leaseRejectAction = l -> {};
+        final ConcurrentMap<String, String> vmIdTohostNames = new ConcurrentHashMap<>();
+        final ConcurrentMap<String, String> leasesToHostnames = new ConcurrentHashMap<>();
+        final Map<String, AssignableVirtualMachine> avms = new HashMap<>();
+        VMCollection vms = new VMCollection(s -> {
+            AssignableVirtualMachine avm = new AssignableVirtualMachine(
+                    vmIdTohostNames,
+                    leasesToHostnames,
+                    s,
+                    leaseRejectAction,
+                    2,
+                    new TaskTracker(),
+                    false
+            );
+            avms.put(s, avm);
+            return avm;
+        }, AutoScalerTest.hostAttrName);
+        for (int i=0; i < rule.getMaxSize()-1; i++) {
+            vms.addLease(LeaseProvider.getLeaseOffer("host"+i, 4, 4000,
+                    0, 0, ports, attributes1, Collections.singletonMap("GPU", 1.0)));
+        }
+        for (AssignableVirtualMachine avm: avms.values())
+            avm.updateCurrTotalLease();
+        final Map<String, List<String>> map = vms.clonePseudoVMsForGroups(Collections.singletonMap(rule.getRuleName(), 6), s -> rule);
+        Assert.assertNotNull(map);
+        Assert.assertEquals(1, map.size());
+        Assert.assertEquals(rule.getRuleName(), map.keySet().iterator().next());
+        Assert.assertEquals(1, map.values().iterator().next().size());
+    }
+
+    private AutoScaleRule getAutoScaleRule(final String name, final int maxSize) {
+        return new AutoScaleRule() {
+            @Override
+            public String getRuleName() {
+                return name;
+            }
+
+            @Override
+            public int getMinIdleHostsToKeep() {
+                return 0;
+            }
+
+            @Override
+            public int getMaxIdleHostsToKeep() {
+                return 0;
+            }
+
+            @Override
+            public int getMaxSize() {
+                return maxSize;
+            }
+
+            @Override
+            public long getCoolDownSecs() {
+                return 1;
+            }
+
+            @Override
+            public boolean idleMachineTooSmall(VirtualMachineLease lease) {
+                return false;
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
- Fix calculation of number of pseudo VMs to add
- Make full copy of lease when cloning for pseudo VMs
- Don't call reject action on pseudo VM leases
- new unit tests