### PR TITLE
fix VM cloning for pseudo scheduling

### DIFF
--- a/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVMs.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVMs.java
@@ -107,7 +107,13 @@ class AssignableVMs {
     }
 
     Map<String, List<String>> createPseudoHosts(Map<String, Integer> groupCounts, Func1<String, AutoScaleRule> ruleGetter) {
-        return vmCollection.clonePseudoVMsForGroups(groupCounts, ruleGetter);
+        return vmCollection.clonePseudoVMsForGroups(groupCounts, ruleGetter, lease ->
+            lease != null &&
+                    (lease.getAttributeMap() == null ||
+                            lease.getAttributeMap().get(activeVmGroupAttributeName) == null ||
+                            isInActiveVmGroup(lease.getAttributeMap().get(activeVmGroupAttributeName).getText().getValue())
+                    )
+        );
     }
 
     void removePsuedoHosts(Map<String, List<String>> hostsMap) {
@@ -230,6 +236,10 @@ class AssignableVMs {
 
     private boolean isInActiveVmGroup(AssignableVirtualMachine avm) {
         final String attrValue = avm.getAttrValue(activeVmGroupAttributeName);
+        return isInActiveVmGroup(attrValue);
+    }
+
+    private boolean isInActiveVmGroup(String attrValue) {
         return activeVmGroups.isActiveVmGroup(attrValue, false);
     }
 

--- a/fenzo-core/src/test/java/com/netflix/fenzo/ShortfallAutoscalerTest.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/ShortfallAutoscalerTest.java
@@ -128,8 +128,8 @@ public class ShortfallAutoscalerTest {
             requests.add(QueuableTaskProvider.wrapTask(qA1, TaskRequestProvider .getTaskRequest(1, memMultiplier, 1)));
         System.out.println("Created " + requests.size() + " tasks");
         final List<VirtualMachineLease> leases = new ArrayList<>();
-        leases.add(LeaseProvider.getLeaseOffer("host1", cpus1, cpus1 * 1000, ports, attributes1));
-        leases.add(LeaseProvider.getLeaseOffer("host2", cpus1, cpus1 * 1000, ports, attributes1));
+        leases.add(LeaseProvider.getLeaseOffer("host1", cpus1, cpus1 * memMultiplier, ports, attributes1));
+        leases.add(LeaseProvider.getLeaseOffer("host2", cpus1, cpus1 * memMultiplier, ports, attributes1));
         for (QueuableTask t: requests) {
             queue.queueTask(t);
         }

--- a/fenzo-core/src/test/java/com/netflix/fenzo/VMCollectionTest.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/VMCollectionTest.java
@@ -35,15 +35,30 @@ import static org.junit.Assert.*;
 public class VMCollectionTest {
 
     private final Map<String, Protos.Attribute> attributes1 = new HashMap<>();
+    private final Map<String, Protos.Attribute> activeVmAttribute1 = new HashMap<>();
+    private final Map<String, Protos.Attribute> activeVmAttribute2 = new HashMap<>();
     private final List<VirtualMachineLease.Range> ports = new ArrayList<>();
     private final String attributeVal1 = "4cores";
+    private final String vmAttrVal1 = "val1";
+    private final String vmAttrVal2 = "val2";
+    private final String activeAttr = "Asg";
 
     @Before
     public void setUp() throws Exception {
-        Protos.Attribute attribute = Protos.Attribute.newBuilder().setName(AutoScalerTest.hostAttrName)
+        Protos.Attribute attribute = Protos.Attribute.newBuilder().setName(activeAttr)
                 .setType(Protos.Value.Type.TEXT)
                 .setText(Protos.Value.Text.newBuilder().setValue(attributeVal1)).build();
         attributes1.put(AutoScalerTest.hostAttrName, attribute);
+        Protos.Attribute vmAttr1 = Protos.Attribute.newBuilder().setName(activeAttr)
+                .setType(Protos.Value.Type.TEXT)
+                .setText(Protos.Value.Text.newBuilder().setValue(vmAttrVal1)).build();
+        activeVmAttribute1.put(activeAttr, vmAttr1);
+        activeVmAttribute1.put(AutoScalerTest.hostAttrName, attribute);
+        Protos.Attribute vmAttr2 = Protos.Attribute.newBuilder().setName(activeAttr)
+                .setType(Protos.Value.Type.TEXT)
+                .setText(Protos.Value.Text.newBuilder().setValue(vmAttrVal2)).build();
+        activeVmAttribute2.put(activeAttr, vmAttr2);
+        activeVmAttribute2.put(AutoScalerTest.hostAttrName, attribute);
         ports.add(new VirtualMachineLease.Range(1, 100));
     }
 
@@ -54,30 +69,78 @@ public class VMCollectionTest {
         final ConcurrentMap<String, String> vmIdTohostNames = new ConcurrentHashMap<>();
         final ConcurrentMap<String, String> leasesToHostnames = new ConcurrentHashMap<>();
         final Map<String, AssignableVirtualMachine> avms = new HashMap<>();
-        VMCollection vms = new VMCollection(s -> {
-            AssignableVirtualMachine avm = new AssignableVirtualMachine(
-                    vmIdTohostNames,
-                    leasesToHostnames,
-                    s,
-                    leaseRejectAction,
-                    2,
-                    new TaskTracker(),
-                    false
-            );
-            avms.put(s, avm);
-            return avm;
-        }, AutoScalerTest.hostAttrName);
+        final TaskTracker taskTracker = new TaskTracker();
+        VMCollection vms = createVmCollection(vmIdTohostNames, leasesToHostnames, taskTracker, avms);
         for (int i=0; i < rule.getMaxSize()-1; i++) {
             vms.addLease(LeaseProvider.getLeaseOffer("host"+i, 4, 4000,
                     0, 0, ports, attributes1, Collections.singletonMap("GPU", 1.0)));
         }
         for (AssignableVirtualMachine avm: avms.values())
             avm.updateCurrTotalLease();
-        final Map<String, List<String>> map = vms.clonePseudoVMsForGroups(Collections.singletonMap(rule.getRuleName(), 6), s -> rule);
+        final Map<String, List<String>> map = vms.clonePseudoVMsForGroups(
+                Collections.singletonMap(rule.getRuleName(), 6), s -> rule,
+                lease -> true
+        );
         Assert.assertNotNull(map);
         Assert.assertEquals(1, map.size());
         Assert.assertEquals(rule.getRuleName(), map.keySet().iterator().next());
         Assert.assertEquals(1, map.values().iterator().next().size());
+    }
+
+    @Test
+    public void testWithInactiveAgents() throws Exception {
+        AutoScaleRule rule = getAutoScaleRule(attributeVal1, 4);
+        final ConcurrentMap<String, String> vmIdTohostNames = new ConcurrentHashMap<>();
+        final ConcurrentMap<String, String> leasesToHostnames = new ConcurrentHashMap<>();
+        final Map<String, AssignableVirtualMachine> avms = new HashMap<>();
+        TaskTracker taskTracker = new TaskTracker();
+        VMCollection vms = createVmCollection(vmIdTohostNames, leasesToHostnames, taskTracker, avms);
+        // create leases for ruleMax-2 VMs for each of vmAttrVal1 and vmAttrVal2
+        for (int i=0; i<rule.getMaxSize()-2; i++) {
+            vms.addLease(LeaseProvider.getLeaseOffer("host-a1-"+i, 4, 4000, 0, 0,
+                    ports, activeVmAttribute1, Collections.singletonMap("GPU", 1.0)));
+            vms.addLease(LeaseProvider.getLeaseOffer("host-a2-"+i, 4, 4000, 0, 0,
+                    ports, activeVmAttribute2, Collections.singletonMap("GPU", 1.0)));
+        }
+        for (AssignableVirtualMachine avm: avms.values())
+            avm.updateCurrTotalLease();
+        final Map<String, List<String>> map = vms.clonePseudoVMsForGroups(
+                Collections.singletonMap(rule.getRuleName(), 7), s -> rule,
+                lease -> {
+                    System.out.println("Comparing " + vmAttrVal2 + " with " + lease.getAttributeMap().get(activeAttr).getText().getValue());
+                    return vmAttrVal2.equals(lease.getAttributeMap().get(activeAttr).getText().getValue());
+                }
+        );
+        Assert.assertNotNull(map);
+        Assert.assertEquals(1, map.size());
+        Assert.assertEquals(2, map.values().iterator().next().size());
+        for (String h: map.values().iterator().next()) {
+            final AssignableVirtualMachine avm = avms.get(h);
+            Assert.assertNotNull(avm);
+            avm.updateCurrTotalLease();
+            final String attrValue = avm.getAttrValue(activeAttr);
+            Assert.assertTrue("Invalid to get host " + h + " with attrVal " + attrValue,
+                    vmAttrVal2.equals(attrValue));
+        }
+    }
+
+    private VMCollection createVmCollection(ConcurrentMap<String, String> vmIdTohostNames,
+                                            ConcurrentMap<String, String> leasesToHostnames, TaskTracker taskTracker,
+                                            Map<String, AssignableVirtualMachine> avms) {
+        Action1<VirtualMachineLease> leaseRejectAction = l -> {};
+        return new VMCollection(s -> {
+            AssignableVirtualMachine avm = new AssignableVirtualMachine(
+                    vmIdTohostNames,
+                    leasesToHostnames,
+                    s,
+                    leaseRejectAction,
+                    2,
+                    taskTracker,
+                    false
+            );
+            avms.put(s, avm);
+            return avm;
+        }, AutoScalerTest.hostAttrName);
     }
 
     private AutoScaleRule getAutoScaleRule(final String name, final int maxSize) {


### PR DESCRIPTION
1. check if lease is rejectable before calling reject action. 
2. filter out leases from inactive VMs before cloning