### PR TITLE
Handle idle/inactive VMs directly in AutoScaler

### DIFF
--- a/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVMs.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVMs.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 class AssignableVMs {
 
@@ -281,6 +282,10 @@ class AssignableVMs {
         taskTracker.setTotalResources(totalResourcesMap);
         //Collections.sort(vms);
         return vms;
+    }
+
+    List<AssignableVirtualMachine> getInactiveVMs() {
+        return vmCollection.getAllVMs().stream().filter(avm -> !isInActiveVmGroup(avm)).collect(Collectors.toList());
     }
 
     private void resetTotalResources() {

--- a/fenzo-core/src/main/java/com/netflix/fenzo/AutoScalerInput.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/AutoScalerInput.java
@@ -21,15 +21,21 @@ import java.util.Set;
 
 class AutoScalerInput {
     private final List<VirtualMachineLease> idleResourcesList;
+    private final List<VirtualMachineLease> idleInactiveResources;
     private final Set<TaskRequest> failedTasks;
 
-    AutoScalerInput(List<VirtualMachineLease> idleResources, Set<TaskRequest> failedTasks) {
+    AutoScalerInput(List<VirtualMachineLease> idleResources, List<VirtualMachineLease> idleInactiveResources, Set<TaskRequest> failedTasks) {
         this.idleResourcesList= idleResources;
+        this.idleInactiveResources = idleInactiveResources;
         this.failedTasks = failedTasks;
     }
 
     public List<VirtualMachineLease> getIdleResourcesList() {
         return idleResourcesList;
+    }
+
+    public List<VirtualMachineLease> getIdleInactiveResourceList() {
+        return idleInactiveResources;
     }
 
     public Set<TaskRequest> getFailures() {


### PR DESCRIPTION
The scale down constraint evaluators work with the merged active/inactive lists,
but we need to do extra processing in AutoScaler to enforce min/max idle constraint
for the active server groups.