### PR TITLE
Change order of releasing leases

### DIFF
--- a/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVMs.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVMs.java
@@ -265,9 +265,9 @@ class AssignableVMs {
 
     List<AssignableVirtualMachine> prepareAndGetOrderedVMs(List<VirtualMachineLease> newLeases, AtomicInteger rejectedCount) {
         disableVMs();
-        expireAnyUnknownLeaseIds();
         removeExpiredLeases();
         rejectedCount.addAndGet(addLeases(newLeases));
+        expireAnyUnknownLeaseIds();
         List<AssignableVirtualMachine> vms = new ArrayList<>();
         taskTracker.clearAssignedTasks();
         vmRejectLimiter.reset();


### PR DESCRIPTION
expire any unknown lease Ids after adding new leases when preparing VMs for scheduling