### PR TITLE
Use hostname as a tie break when fitness is equal

### DIFF
--- a/fenzo-core/src/main/java/com/netflix/fenzo/TaskScheduler.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/TaskScheduler.java
@@ -505,7 +505,8 @@ public class TaskScheduler {
             // change to using fitness value from assignment result
             TaskAssignmentResult res = results.get(r);
             if(res!=null && res.isSuccessful()) {
-                if(bestResult==null || res.getFitness()>bestFitness) {
+                if(bestResult==null || res.getFitness()>bestFitness ||
+                        (res.getFitness()==bestFitness && res.getHostname().compareTo(bestResult.getHostname())<0)) {
                     bestFitness = res.getFitness();
                     bestResult = res;
                 }


### PR DESCRIPTION
I can't figure out why this was commented out. Was this intentional? 

It causes scheduling with fenzo to non-deterministic with a large number of hosts which makes simulating a framework that uses fenzo difficult.