### PR TITLE
Execute autoscaler synchronously on scheduler thread

### DIFF
--- a/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVMs.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVMs.java
@@ -117,7 +117,7 @@ class AssignableVMs {
         );
     }
 
-    void removePsuedoHosts(Map<String, List<String>> hostsMap) {
+    void removePseudoHosts(Map<String, List<String>> hostsMap) {
         if (hostsMap != null && !hostsMap.isEmpty()) {
             for (Map.Entry<String, List<String>> entry: hostsMap.entrySet()) {
                 for (String h: entry.getValue()) {

--- a/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVirtualMachine.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVirtualMachine.java
@@ -617,7 +617,7 @@ class AssignableVirtualMachine implements Comparable<AssignableVirtualMachine>{
         return result;
     }
 
-    Map<VMResource, Double> getMaxResources() {
+    public Map<VMResource, Double> getMaxResources() {
         double cpus=0.0;
         double memory=0.0;
         double network=0.0;
@@ -660,7 +660,7 @@ class AssignableVirtualMachine implements Comparable<AssignableVirtualMachine>{
      */
     TaskAssignmentResult tryRequest(TaskRequest request, VMTaskFitnessCalculator fitnessCalculator) {
         if(logger.isDebugEnabled())
-            logger.debug("Host {} task {}: #leases=", getHostname(), request.getId(), leasesMap.size());
+            logger.debug("Host {} task {}: #leases: {}", getHostname(), request.getId(), leasesMap.size());
         if(leasesMap.isEmpty())
             return null;
         if(exclusiveTaskId!=null) {

--- a/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVirtualMachine.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVirtualMachine.java
@@ -617,7 +617,7 @@ class AssignableVirtualMachine implements Comparable<AssignableVirtualMachine>{
         return result;
     }
 
-    public Map<VMResource, Double> getMaxResources() {
+    Map<VMResource, Double> getMaxResources() {
         double cpus=0.0;
         double memory=0.0;
         double network=0.0;

--- a/fenzo-core/src/main/java/com/netflix/fenzo/AutoScaler.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/AutoScaler.java
@@ -124,7 +124,7 @@ class AutoScaler {
         this.taskToClustersGetter = getter;
     }
 
-    void scheduleAutoscale(final AutoScalerInput autoScalerInput) {
+    void doAutoscale(final AutoScalerInput autoScalerInput) {
         if (isShutdown.get()) {
             return;
         }
@@ -227,7 +227,7 @@ class AutoScaler {
                     StringBuilder sBuilder = new StringBuilder();
                     for (String host : hostsToTerminate.keySet()) {
                         sBuilder.append(host).append(", ");
-                        long disabledDurationInSecs = (disabledVmDurationInSecs > 0L) ? disabledVmDurationInSecs : rule.getCoolDownSecs();
+                        long disabledDurationInSecs = Math.max(disabledVmDurationInSecs, rule.getCoolDownSecs());
                         assignableVMs.disableUntil(host, now + disabledDurationInSecs * 1000);
                     }
                     logger.info("Scaling down " + rule.getRuleName() + " by "

--- a/fenzo-core/src/main/java/com/netflix/fenzo/OptimizingShortfallEvaluator.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/OptimizingShortfallEvaluator.java
@@ -42,7 +42,7 @@ import java.util.Set;
  * The pseudo scheduling run performs an entire scheduling iteration using the cloned queue and pseudo VMs in addition
  * to any new VM leases that have been added since previous scheduling iteration. This will invoke any and all task
  * constraints as well as fitness function setup in the scheduler. The scheduling result is used to determine the
- * number of VMs in each group and then the results are discarded. As expected, the psuedo scheduling run has no impact
+ * number of VMs in each group and then the results are discarded. As expected, the pseudo scheduling run has no impact
  * on the real scheduling assignments made.
  * <P>
  * Tasks for which scale up is requested by this evaluator are remembered and not requested again until certain delay.
@@ -63,7 +63,7 @@ class OptimizingShortfallEvaluator extends BaseShortfallEvaluator {
             return Collections.emptyMap();
 
         final InternalTaskQueue taskQueue = createAndFillAlternateQueue(filteredTasks);
-        return schedulingService.requestPsuedoScheduling(taskQueue, shortfallTasksPerGroup);
+        return schedulingService.requestPseudoScheduling(taskQueue, shortfallTasksPerGroup);
     }
 
     private InternalTaskQueue createAndFillAlternateQueue(List<TaskRequest> shortfallTasks) {

--- a/fenzo-core/src/main/java/com/netflix/fenzo/StateMonitor.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/StateMonitor.java
@@ -16,27 +16,21 @@
 
 package com.netflix.fenzo;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * A monitor to ensure scheduler state is not compromised by concurrent calls that are disallowed.
  */
 class StateMonitor {
-    private final AtomicBoolean lock;
-
-    StateMonitor() {
-        lock = new AtomicBoolean(false);
-    }
+    private final ReentrantLock lock = new ReentrantLock();
 
     AutoCloseable enter() {
-        if(!lock.compareAndSet(false, true))
+        if (!lock.tryLock()) {
             throw new IllegalStateException();
-        return new AutoCloseable() {
-            @Override
-            public void close() throws Exception {
-                if(!lock.compareAndSet(true, false))
-                    throw new IllegalStateException();
-            }
+        }
+        return () -> {
+            if (!lock.tryLock())
+                throw new IllegalStateException();
         };
     }
 

--- a/fenzo-core/src/main/java/com/netflix/fenzo/TaskSchedulingService.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/TaskSchedulingService.java
@@ -150,8 +150,8 @@ public class TaskSchedulingService {
         return taskQueue;
     }
 
-    /* package */ Map<String, Integer> requestPsuedoScheduling(final InternalTaskQueue pTaskQueue, Map<String, Integer> groupCounts) {
-        Map<String, Integer> psuedoSchedulingResult;
+    /* package */ Map<String, Integer> requestPseudoScheduling(final InternalTaskQueue pTaskQueue, Map<String, Integer> groupCounts) {
+        Map<String, Integer> pseudoSchedulingResult = new HashMap<>();
             try {
                 logger.debug("Creating pseudo hosts");
                 final Map<String, List<String>> pseudoHosts = taskScheduler.createPseudoHosts(groupCounts);
@@ -183,7 +183,7 @@ public class TaskSchedulingService {
                     // temporarily replace usage tracker in taskTracker to the pseudoQ and then put back the original one
                     taskScheduler.getTaskTracker().setUsageTrackedQueue(pTaskQueue.getUsageTracker());
                     logger.debug("Scheduling with pseudoQ");
-                    final SchedulingResult schedulingResult = taskScheduler.scheduleOnce(pTaskQueue, Collections.emptyList());
+                    final SchedulingResult schedulingResult = taskScheduler.pseudoScheduleOnce(pTaskQueue);
                     final Map<String, VMAssignmentResult> resultMap = schedulingResult.getResultMap();
                     Map<String, Integer> result = new HashMap<>();
                     if (!resultMap.isEmpty()) {
@@ -223,23 +223,22 @@ public class TaskSchedulingService {
                             }
                         }
                     }
-                    psuedoSchedulingResult = result;
+                    pseudoSchedulingResult = result;
                 }
                 catch (Exception e) {
                     logger.error("Error in pseudo scheduling", e);
                     throw e;
                 }
                 finally {
-                    taskScheduler.removePsuedoHosts(pseudoHosts);
-                    taskScheduler.removePsuedoAssignments();
+                    taskScheduler.removePseudoHosts(pseudoHosts);
+                    taskScheduler.removePseudoAssignments();
                     taskScheduler.getTaskTracker().setUsageTrackedQueue(taskQueue.getUsageTracker());
                 }
             }
             catch (Exception e) {
                 logger.error("Error in pseudo scheduling", e);
-                throw e;
             }
-        return psuedoSchedulingResult;
+        return pseudoSchedulingResult;
     }
 
     private void scheduleOnce() {

--- a/fenzo-core/src/main/java/com/netflix/fenzo/VMCollection.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/VMCollection.java
@@ -59,10 +59,10 @@ class VMCollection {
     }
 
     /**
-     * Create <code>n</code> psuedo VMs for each group by cloning a VM in each group.
+     * Create <code>n</code> pseudo VMs for each group by cloning a VM in each group.
      * @param groupCounts Map with keys contain group names and values containing number of agents to clone
      * @param ruleGetter Getter function for autoscale rules
-     * @return Collection of psuedo host names added.
+     * @return Collection of pseudo host names added.
      */
     Map<String, List<String>> clonePseudoVMsForGroups(Map<String, Integer> groupCounts,
                                                       Func1<String, AutoScaleRule> ruleGetter,

--- a/fenzo-core/src/main/java/com/netflix/fenzo/VMCollection.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/VMCollection.java
@@ -78,8 +78,10 @@ class VMCollection {
             result.put(g, hostnames);
             final ConcurrentMap<String, AssignableVirtualMachine> avmsMap = vms.get(g);
             if (avmsMap != null) {
-                final List<AssignableVirtualMachine> vmsList = avmsMap.values().stream()
-                        .filter(avm -> vmFilter.test(avm.getCurrTotalLease())).collect(Collectors.toList());
+                final List<AssignableVirtualMachine> vmsList = avmsMap.values()
+                        .stream()
+                        .filter(avm -> vmFilter.test(avm.getCurrTotalLease()))
+                        .collect(Collectors.toList());
                 if (vmsList != null && !vmsList.isEmpty()) {
                     // NOTE: a shortcoming here is that the attributes of VMs across a group may not be homogeneous.
                     // By creating one lease object and cloning from it, we pick one combination of the attributes

--- a/fenzo-core/src/main/java/com/netflix/fenzo/samples/SampleQbasedScheduling.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/samples/SampleQbasedScheduling.java
@@ -168,7 +168,7 @@ public class SampleQbasedScheduling {
                         System.out.println("Starting scheduling iteration " + schedCounter.incrementAndGet());
                     }
                 })
-                .withTaskQuue(queue)
+                .withTaskQueue(queue)
                 .withTaskScheduler(taskScheduler)
                 // TaskSchedulingService will call us back when there are task assignments. Handle them by launching
                 // tasks using MesosDriver

--- a/fenzo-core/src/test/java/com/netflix/fenzo/AutoScalerTest.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/AutoScalerTest.java
@@ -16,10 +16,25 @@
 
 package com.netflix.fenzo;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.netflix.fenzo.functions.Action1;
+import com.netflix.fenzo.functions.Func1;
 import com.netflix.fenzo.plugins.BinPackingFitnessCalculators;
 import com.netflix.fenzo.plugins.HostAttrValueConstraint;
 import com.netflix.fenzo.queues.QAttributes;
-import com.netflix.fenzo.queues.QueuableTask;
 import com.netflix.fenzo.queues.TaskQueue;
 import com.netflix.fenzo.queues.TaskQueues;
 import com.netflix.fenzo.queues.tiered.QueuableTaskProvider;
@@ -28,30 +43,47 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import com.netflix.fenzo.functions.Action1;
-import com.netflix.fenzo.functions.Func1;
-
-import java.util.*;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class AutoScalerTest {
 
+    static final Action1<VirtualMachineLease> noOpLeaseReject = lease -> {
+    };
     static String hostAttrName = "MachineType";
-    final int minIdle=5;
-    final int maxIdle=10;
-    final long coolDownSecs=2;
-    final String hostAttrVal1="4coreServers";
-    final String hostAttrVal2="8coreServers";
-    int cpus1=4;
-    int memory1=40000;
-    int cpus2=8;
-    int memory2=800;  // make this less than memory1/cpus1 to ensure jobs don't get on these
-    final AutoScaleRule rule1 = AutoScaleRuleProvider.createRule(hostAttrVal1, minIdle, maxIdle, coolDownSecs, cpus1/2, memory1/2);
-    final AutoScaleRule rule2 = AutoScaleRuleProvider.createRule(hostAttrVal2, minIdle, maxIdle, coolDownSecs, cpus2/2, memory2/2);
+    final int minIdle = 5;
+    final int maxIdle = 10;
+    final long coolDownSecs = 2;
+    final String hostAttrVal1 = "4coreServers";
+    final String hostAttrVal2 = "8coreServers";
+    int cpus1 = 4;
+    int memory1 = 40000;
+    final AutoScaleRule rule1 = AutoScaleRuleProvider.createRule(hostAttrVal1, minIdle, maxIdle, coolDownSecs, cpus1 / 2, memory1 / 2);
+    int cpus2 = 8;
+    int memory2 = 800;  // make this less than memory1/cpus1 to ensure jobs don't get on these
+    final AutoScaleRule rule2 = AutoScaleRuleProvider.createRule(hostAttrVal2, minIdle, maxIdle, coolDownSecs, cpus2 / 2, memory2 / 2);
+
+    /* package */
+    static TaskScheduler getScheduler(final Action1<VirtualMachineLease> leaseRejectCalback, final Action1<AutoScaleAction> callback,
+                                      long delayScaleUpBySecs, long delayScaleDownByDecs,
+                                      AutoScaleRule... rules) {
+        TaskScheduler.Builder builder = new TaskScheduler.Builder()
+                .withAutoScaleByAttributeName(hostAttrName);
+        for (AutoScaleRule rule : rules)
+            builder.withAutoScaleRule(rule);
+        if (callback != null)
+            builder.withAutoScalerCallback(callback);
+        return builder
+                .withDelayAutoscaleDownBySecs(delayScaleDownByDecs)
+                .withDelayAutoscaleUpBySecs(delayScaleUpBySecs)
+                .withFitnessCalculator(BinPackingFitnessCalculators.cpuMemBinPacker)
+                .withLeaseOfferExpirySecs(3600)
+                .withLeaseRejectAction(lease -> {
+                    if (leaseRejectCalback == null)
+                        Assert.fail("Unexpected to reject lease " + lease.hostname());
+                    else
+                        leaseRejectCalback.call(lease);
+                })
+                .build();
+    }
 
     @Before
     public void setUp() throws Exception {
@@ -63,39 +95,17 @@ public class AutoScalerTest {
 
     }
 
-    static final Action1<VirtualMachineLease> noOpLeaseReject = lease -> {};
-
     private TaskScheduler getScheduler(AutoScaleRule... rules) {
         return getScheduler(null, rules);
     }
+
     private TaskScheduler getScheduler(final Action1<VirtualMachineLease> leaseRejectCalback, AutoScaleRule... rules) {
         return getScheduler(leaseRejectCalback, null, 0, 0, rules);
     }
+
     private TaskScheduler getScheduler(final Action1<VirtualMachineLease> leaseRejectCalback, final Action1<AutoScaleAction> callback,
                                        AutoScaleRule... rules) {
         return getScheduler(leaseRejectCalback, callback, 0, 0, rules);
-    }
-    /* package */ static TaskScheduler getScheduler(final Action1<VirtualMachineLease> leaseRejectCalback, final Action1<AutoScaleAction> callback,
-                                       long delayScaleUpBySecs, long delayScaleDownByDecs,
-                                       AutoScaleRule... rules) {
-        TaskScheduler.Builder builder = new TaskScheduler.Builder()
-                .withAutoScaleByAttributeName(hostAttrName);
-        for(AutoScaleRule rule: rules)
-            builder.withAutoScaleRule(rule);
-        if(callback != null)
-            builder.withAutoScalerCallback(callback);
-        return builder
-                .withDelayAutoscaleDownBySecs(delayScaleDownByDecs)
-                .withDelayAutoscaleUpBySecs(delayScaleUpBySecs)
-                .withFitnessCalculator(BinPackingFitnessCalculators.cpuMemBinPacker)
-                .withLeaseOfferExpirySecs(3600)
-                .withLeaseRejectAction(lease -> {
-                    if(leaseRejectCalback == null)
-                        Assert.fail("Unexpected to reject lease " + lease.hostname());
-                    else
-                        leaseRejectCalback.call(lease);
-                })
-                .build();
     }
 
     // Test autoscale up on a simple rule
@@ -111,20 +121,20 @@ public class AutoScalerTest {
         scheduler.setAutoscalerCallback(new Action1<AutoScaleAction>() {
             @Override
             public void call(AutoScaleAction action) {
-                if(action instanceof ScaleUpAction) {
-                    int needed = ((ScaleUpAction)action).getScaleUpCount();
+                if (action instanceof ScaleUpAction) {
+                    int needed = ((ScaleUpAction) action).getScaleUpCount();
                     scaleUpRequest.set(needed);
                     latch.countDown();
                 }
             }
         });
         List<TaskRequest> requests = new ArrayList<>();
-        int i=0;
+        int i = 0;
         do {
             Thread.sleep(1000);
             scheduler.scheduleOnce(requests, leases);
-        } while (i++<(coolDownSecs+2) && latch.getCount()>0);
-        if(latch.getCount()>0)
+        } while (i++ < (coolDownSecs + 2) && latch.getCount() > 0);
+        if (latch.getCount() > 0)
             Assert.fail("Timed out scale up action");
         else
             Assert.assertEquals(maxIdle, scaleUpRequest.get());
@@ -145,7 +155,7 @@ public class AutoScalerTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicBoolean addVMs = new AtomicBoolean(false);
         final List<TaskRequest> requests = new ArrayList<>();
-        for(int i=0; i<maxIdle*cpus1; i++)
+        for (int i = 0; i < maxIdle * cpus1; i++)
             requests.add(TaskRequestProvider.getTaskRequest(1.0, 100, 1));
         scheduler.setAutoscalerCallback(new Action1<AutoScaleAction>() {
             @Override
@@ -158,30 +168,31 @@ public class AutoScalerTest {
                 }
             }
         });
-        int i=0;
-        boolean added=false;
+        int i = 0;
+        boolean added = false;
         do {
             Thread.sleep(1000);
-            if(!added && addVMs.get()) {
+            if (!added && addVMs.get()) {
                 leases.addAll(LeaseProvider.getLeases(maxIdle, cpus1, memory1, 1, 10));
-                added=true;
+                added = true;
             }
             SchedulingResult schedulingResult = scheduler.scheduleOnce(requests, leases);
-            Map<String,VMAssignmentResult> resultMap = schedulingResult.getResultMap();
-            if(added) {
-                int count=0;
-                for(VMAssignmentResult result: resultMap.values())
+            Map<String, VMAssignmentResult> resultMap = schedulingResult.getResultMap();
+            if (added) {
+                int count = 0;
+                for (VMAssignmentResult result : resultMap.values())
                     count += result.getTasksAssigned().size();
                 Assert.assertEquals(requests.size(), count);
                 requests.clear();
                 leases.clear();
             }
-        } while (i++<(2*coolDownSecs+2) && latch.getCount()>0);
-        Assert.assertTrue("Second scale up action didn't arrive on time", latch.getCount()==0);
+        } while (i++ < (2 * coolDownSecs + 2) && latch.getCount() > 0);
+        Assert.assertTrue("Second scale up action didn't arrive on time", latch.getCount() == 0);
     }
 
     /**
      * Tests that the rule applies only to the host types specified and not to the other host type.
+     *
      * @throws Exception upon any error
      */
     @Test
@@ -195,19 +206,20 @@ public class AutoScalerTest {
         }, rule2);
         final List<TaskRequest> requests = new ArrayList<>();
         final List<VirtualMachineLease> leases = new ArrayList<>();
-        for(int i=0; i<maxIdle*cpus1; i++)
+        for (int i = 0; i < maxIdle * cpus1; i++)
             requests.add(TaskRequestProvider.getTaskRequest(1.0, 100, 1));
-        int i=0;
+        int i = 0;
         do {
             Thread.sleep(1000);
             scheduler.scheduleOnce(requests, leases);
-        } while(i++<coolDownSecs+2 && latch.getCount()>0);
-        if(latch.getCount()<1)
+        } while (i++ < coolDownSecs + 2 && latch.getCount() > 0);
+        if (latch.getCount() < 1)
             Assert.fail("Should not have gotten scale up action for " + rule1.getRuleName());
     }
 
     /**
      * Tests that of the two AutoScale rules setup, scale up action is called only on the one that is actually short.
+     *
      * @throws Exception
      */
     @Test
@@ -232,22 +244,23 @@ public class AutoScalerTest {
                 .setType(Protos.Value.Type.TEXT)
                 .setText(Protos.Value.Text.newBuilder().setValue(hostAttrVal2)).build();
         attributes.put(hostAttrName, attribute);
-        for(int l=0; l<maxIdle; l++) {
-            leases.add(LeaseProvider.getLeaseOffer("host"+l, 8, 8000, ports, attributes));
+        for (int l = 0; l < maxIdle; l++) {
+            leases.add(LeaseProvider.getLeaseOffer("host" + l, 8, 8000, ports, attributes));
         }
-        int i=0;
+        int i = 0;
         do {
             Thread.sleep(1000);
             scheduler.scheduleOnce(requests, leases);
             leases.clear();
-        } while (i++<coolDownSecs+2 && latch.getCount()>0);
-        if(latch.getCount()<1)
+        } while (i++ < coolDownSecs + 2 && latch.getCount() > 0);
+        if (latch.getCount() < 1)
             Assert.fail("Scale up action received for " + rule2.getRuleName() + " rule, was expecting only on "
                     + rule1.getRuleName());
     }
 
     /**
      * Tests simple scale down action on host type that has excess capacity
+     *
      * @throws Exception
      */
     @Test
@@ -255,7 +268,7 @@ public class AutoScalerTest {
         final AtomicInteger scaleDownCount = new AtomicInteger();
         TaskScheduler scheduler = getScheduler(noOpLeaseReject, rule1);
         final List<TaskRequest> requests = new ArrayList<>();
-        for(int c=0; c<cpus1; c++) // add as many 1-CPU requests as #cores on a host
+        for (int c = 0; c < cpus1; c++) // add as many 1-CPU requests as #cores on a host
             requests.add(TaskRequestProvider.getTaskRequest(1, 1000, 1));
         final List<VirtualMachineLease> leases = new ArrayList<>();
         final CountDownLatch latch = new CountDownLatch(1);
@@ -275,28 +288,29 @@ public class AutoScalerTest {
                 .setType(Protos.Value.Type.TEXT)
                 .setText(Protos.Value.Text.newBuilder().setValue(hostAttrVal1)).build();
         attributes.put(hostAttrName, attribute);
-        int excess=3;
-        for(int l=0; l<maxIdle+excess; l++) {
-            leases.add(LeaseProvider.getLeaseOffer("host"+l, cpus1, memory1, ports, attributes));
+        int excess = 3;
+        for (int l = 0; l < maxIdle + excess; l++) {
+            leases.add(LeaseProvider.getLeaseOffer("host" + l, cpus1, memory1, ports, attributes));
         }
-        int i=0;
-        boolean first=true;
+        int i = 0;
+        boolean first = true;
         do {
             Thread.sleep(1000);
             final SchedulingResult schedulingResult = scheduler.scheduleOnce(requests, leases);
-            if(first) {
-                first=false;
+            if (first) {
+                first = false;
                 leases.clear();
                 requests.clear();
             }
-        } while(i++<coolDownSecs+2 && latch.getCount()>0);
+        } while (i++ < coolDownSecs + 2 && latch.getCount() > 0);
         Assert.assertEquals(0, latch.getCount());
         // expect scale down count to be excess-1 since we used up 1 host
-        Assert.assertEquals(excess-1, scaleDownCount.get());
+        Assert.assertEquals(excess - 1, scaleDownCount.get());
     }
 
     /**
      * Tests that of the two rules, scale down is called only on the one that is in excess
+     *
      * @throws Exception
      */
     @Test
@@ -316,8 +330,8 @@ public class AutoScalerTest {
             }
         });
         // use up servers covered by rule1
-        for(int r=0; r<maxIdle*cpus1; r++)
-            requests.add(TaskRequestProvider.getTaskRequest(1, memory1/cpus1, 1));
+        for (int r = 0; r < maxIdle * cpus1; r++)
+            requests.add(TaskRequestProvider.getTaskRequest(1, memory1 / cpus1, 1));
         List<VirtualMachineLease.Range> ports = new ArrayList<>();
         ports.add(new VirtualMachineLease.Range(1, 10));
         Map<String, Protos.Attribute> attributes1 = new HashMap<>();
@@ -330,22 +344,22 @@ public class AutoScalerTest {
                 .setType(Protos.Value.Type.TEXT)
                 .setText(Protos.Value.Text.newBuilder().setValue(hostAttrVal2)).build();
         attributes2.put(hostAttrName, attribute2);
-        for(int l=0; l<maxIdle+3; l++) {
-            leases.add(LeaseProvider.getLeaseOffer("host"+l, cpus1, memory1, ports, attributes1));
-            leases.add(LeaseProvider.getLeaseOffer("host"+100+l, cpus2, memory2, ports, attributes2));
+        for (int l = 0; l < maxIdle + 3; l++) {
+            leases.add(LeaseProvider.getLeaseOffer("host" + l, cpus1, memory1, ports, attributes1));
+            leases.add(LeaseProvider.getLeaseOffer("host" + 100 + l, cpus2, memory2, ports, attributes2));
         }
-        int i=0;
-        boolean first=true;
+        int i = 0;
+        boolean first = true;
         do {
             Thread.sleep(1000);
             scheduler.scheduleOnce(requests, leases);
-            if(first) {
-                first=false;
+            if (first) {
+                first = false;
                 requests.clear();
                 leases.clear();
             }
-        } while (i++<coolDownSecs+2 && latch.getCount()>0);
-        if(latch.getCount()<1)
+        } while (i++ < coolDownSecs + 2 && latch.getCount() > 0);
+        if (latch.getCount() < 1)
             Assert.fail("Scale down action received for " + wrongScaleDownRulename + " rule, was expecting only on "
                     + rule1.getRuleName());
     }
@@ -356,19 +370,19 @@ public class AutoScalerTest {
     // hosts for each zone.
     @Test
     public void testScaleDownBalanced() throws Exception {
-        final String zoneAttrName="Zone";
-        final int mxIdl=12;
+        final String zoneAttrName = "Zone";
+        final int mxIdl = 12;
         final CountDownLatch latch = new CountDownLatch(1);
         final int[] zoneCounts = {0, 0, 0};
         final List<TaskRequest> requests = new ArrayList<>();
         // add enough jobs to fill two machines of zone 0
         List<ConstraintEvaluator> hardConstraints = new ArrayList<>();
         hardConstraints.add(ConstraintsProvider.getHostAttributeHardConstraint(zoneAttrName, "" + 1));
-        for(int j=0; j<cpus1*2; j++) {
-            requests.add(TaskRequestProvider.getTaskRequest(1, memory1/cpus1, 1, hardConstraints, null));
+        for (int j = 0; j < cpus1 * 2; j++) {
+            requests.add(TaskRequestProvider.getTaskRequest(1, memory1 / cpus1, 1, hardConstraints, null));
         }
         final List<VirtualMachineLease> leases = new ArrayList<>();
-        final AutoScaleRule rule = AutoScaleRuleProvider.createRule(hostAttrVal1, 3, mxIdl, coolDownSecs, cpus1/2, memory1/2);
+        final AutoScaleRule rule = AutoScaleRuleProvider.createRule(hostAttrVal1, 3, mxIdl, coolDownSecs, cpus1 / 2, memory1 / 2);
         final TaskScheduler scheduler = new TaskScheduler.Builder()
                 .withAutoScaleByAttributeName(hostAttrName)
                 .withAutoScaleDownBalancedByAttributeName(zoneAttrName)
@@ -404,21 +418,21 @@ public class AutoScalerTest {
         Protos.Attribute attr = Protos.Attribute.newBuilder().setName(hostAttrName)
                 .setType(Protos.Value.Type.TEXT)
                 .setText(Protos.Value.Text.newBuilder().setValue(hostAttrVal1)).build();
-        for(int i=0; i<3; i++) {
+        for (int i = 0; i < 3; i++) {
             attributes.add(new HashMap<String, Protos.Attribute>());
             Protos.Attribute attribute = Protos.Attribute.newBuilder().setName(zoneAttrName)
                     .setType(Protos.Value.Type.TEXT)
-                    .setText(Protos.Value.Text.newBuilder().setValue(""+i)).build();
+                    .setText(Protos.Value.Text.newBuilder().setValue("" + i)).build();
             attributes.get(i).put(zoneAttrName, attribute);
             attributes.get(i).put(hostAttrName, attr);
         }
-        for(int l=0; l<mxIdl+6; l++) {
+        for (int l = 0; l < mxIdl + 6; l++) {
             final int zoneNum = l % 3;
-            leases.add(LeaseProvider.getLeaseOffer("host"+l, cpus1, memory1, ports, attributes.get(zoneNum)));
+            leases.add(LeaseProvider.getLeaseOffer("host" + l, cpus1, memory1, ports, attributes.get(zoneNum)));
             zoneCounts[zoneNum]++;
         }
-        int i=0;
-        boolean first=true;
+        int i = 0;
+        boolean first = true;
         do {
             Thread.sleep(1000);
             final SchedulingResult schedulingResult = scheduler.scheduleOnce(requests, leases);
@@ -426,17 +440,17 @@ public class AutoScalerTest {
 //                    schedulingResult.getLeasesAdded() + ", #totalVms=" + schedulingResult.getTotalVMsCount());
 //            System.out.println("#leasesRejected=" + schedulingResult.getLeasesRejected());
             final Map<String, VMAssignmentResult> resultMap = schedulingResult.getResultMap();
-            for(Map.Entry<String, VMAssignmentResult> entry: resultMap.entrySet()) {
+            for (Map.Entry<String, VMAssignmentResult> entry : resultMap.entrySet()) {
                 final int zn = Integer.parseInt(entry.getValue().getLeasesUsed().get(0).getAttributeMap().get(zoneAttrName).getText().getValue());
                 zoneCounts[zn]--;
             }
-            if(first) {
-                first=false;
+            if (first) {
+                first = false;
                 requests.clear();
                 leases.clear();
             }
-        } while (i++<coolDownSecs+2 && latch.getCount()>0);
-        if(latch.getCount()>0)
+        } while (i++ < coolDownSecs + 2 && latch.getCount() > 0);
+        if (latch.getCount() > 0)
             Assert.fail("Didn't get scale down");
         for (int zoneCount : zoneCounts) {
             Assert.assertEquals(4, zoneCount);
@@ -445,6 +459,7 @@ public class AutoScalerTest {
 
     /**
      * Test that a scaled down host doesn't get used in spite of receiving an offer for it
+     *
      * @throws Exception
      */
     @Test
@@ -454,8 +469,8 @@ public class AutoScalerTest {
         final AtomicReference<Collection<String>> scaleDownHostsRef = new AtomicReference<>();
         final List<TaskRequest> requests = new ArrayList<>();
         final List<VirtualMachineLease> leases = new ArrayList<>();
-        for(int j=0; j<cpus1; j++) // fill one machine
-            requests.add(TaskRequestProvider.getTaskRequest(1, memory1/cpus1, 1));
+        for (int j = 0; j < cpus1; j++) // fill one machine
+            requests.add(TaskRequestProvider.getTaskRequest(1, memory1 / cpus1, 1));
         List<VirtualMachineLease.Range> ports = new ArrayList<>();
         ports.add(new VirtualMachineLease.Range(1, 10));
         Map<String, Protos.Attribute> attributes1 = new HashMap<>();
@@ -463,9 +478,9 @@ public class AutoScalerTest {
                 .setType(Protos.Value.Type.TEXT)
                 .setText(Protos.Value.Text.newBuilder().setValue(hostAttrVal1)).build();
         attributes1.put(hostAttrName, attribute);
-        int excess=3;
-        for(int l=0; l<maxIdle+excess; l++) {
-            leases.add(LeaseProvider.getLeaseOffer("host"+l, cpus1, memory1, ports, attributes1));
+        int excess = 3;
+        for (int l = 0; l < maxIdle + excess; l++) {
+            leases.add(LeaseProvider.getLeaseOffer("host" + l, cpus1, memory1, ports, attributes1));
         }
         scheduler.setAutoscalerCallback(new Action1<AutoScaleAction>() {
             @Override
@@ -476,12 +491,12 @@ public class AutoScalerTest {
                 }
             }
         });
-        int i=0;
-        boolean first=true;
-        while (i++<coolDownSecs+2 && latch.getCount()>0) {
+        int i = 0;
+        boolean first = true;
+        while (i++ < coolDownSecs + 2 && latch.getCount() > 0) {
             scheduler.scheduleOnce(requests, leases);
-            if(first) {
-                first=false;
+            if (first) {
+                first = false;
                 requests.clear();
                 leases.clear();
             }
@@ -490,37 +505,37 @@ public class AutoScalerTest {
         Assert.assertEquals(0, latch.getCount());
         final List<VirtualMachineCurrentState> vmCurrentStates = scheduler.getVmCurrentStates();
         long now = System.currentTimeMillis();
-        for (VirtualMachineCurrentState s: vmCurrentStates) {
+        for (VirtualMachineCurrentState s : vmCurrentStates) {
             if (s.getDisabledUntil() > 0)
                 System.out.println("********** " + s.getHostname() + " disabled for " + (s.getDisabledUntil() - now) +
                         " mSecs");
         }
         // remove any existing leases in scheduler
         // now generate offers for hosts that were scale down and ensure they don't get used
-        for(String hostname: scaleDownHostsRef.get()) {
+        for (String hostname : scaleDownHostsRef.get()) {
             leases.add(LeaseProvider.getLeaseOffer(hostname, cpus1, memory1, ports, attributes1));
         }
         // now try to fill all machines minus one that we filled before
-        for(int j=0; j<(maxIdle+excess-1)*cpus1; j++)
-            requests.add(TaskRequestProvider.getTaskRequest(1, memory1/cpus1, 1));
-        i=0;
-        first=true;
+        for (int j = 0; j < (maxIdle + excess - 1) * cpus1; j++)
+            requests.add(TaskRequestProvider.getTaskRequest(1, memory1 / cpus1, 1));
+        i = 0;
+        first = true;
         do {
             SchedulingResult schedulingResult = scheduler.scheduleOnce(requests, leases);
-            if(!schedulingResult.getResultMap().isEmpty()) {
-                for(Map.Entry<String, VMAssignmentResult> entry: schedulingResult.getResultMap().entrySet()) {
+            if (!schedulingResult.getResultMap().isEmpty()) {
+                for (Map.Entry<String, VMAssignmentResult> entry : schedulingResult.getResultMap().entrySet()) {
                     Assert.assertFalse("Did not expect scaled down host " + entry.getKey() + " to be assigned again",
                             isInCollection(entry.getKey(), scaleDownHostsRef.get()));
-                    for(int j=0; j<entry.getValue().getTasksAssigned().size(); j++)
+                    for (int j = 0; j < entry.getValue().getTasksAssigned().size(); j++)
                         requests.remove(0);
                 }
             }
-            if(first) {
+            if (first) {
                 leases.clear();
                 first = false;
             }
             Thread.sleep(1000);
-        } while(i++<coolDownSecs-1);
+        } while (i++ < coolDownSecs - 1);
     }
 
     // Tests that resource shortfall is evaluated and scale up happens beyond what would otherwise request only up to
@@ -530,7 +545,7 @@ public class AutoScalerTest {
         TaskScheduler scheduler = getScheduler(noOpLeaseReject, AutoScaleRuleProvider.createRule(hostAttrVal1, minIdle, maxIdle, coolDownSecs, 1, 1000));
         final List<TaskRequest> requests = new ArrayList<>();
         final List<VirtualMachineLease> leases = new ArrayList<>();
-        for(int i=0; i<rule1.getMaxIdleHostsToKeep()*2; i++)
+        for (int i = 0; i < rule1.getMaxIdleHostsToKeep() * 2; i++)
             requests.add(TaskRequestProvider.getTaskRequest(1, 1000, 1));
         leases.addAll(LeaseProvider.getLeases(2, 1, 1000, 1, 10));
         final AtomicInteger scaleUpRequested = new AtomicInteger();
@@ -552,10 +567,10 @@ public class AutoScalerTest {
         boolean waitSuccessful = latchRef.get().await(coolDownSecs, TimeUnit.SECONDS);
         Assert.assertTrue(waitSuccessful);
         final int scaleUp = scaleUpRequested.get();
-        Assert.assertEquals(requests.size()-leases.size(), scaleUp);
+        Assert.assertEquals(requests.size() - leases.size(), scaleUp);
         requests.clear();
         final int newRequests = rule1.getMaxIdleHostsToKeep() * 3;
-        for(int i=0; i<newRequests; i++)
+        for (int i = 0; i < newRequests; i++)
             requests.add(TaskRequestProvider.getTaskRequest(1, 1000, 1));
         latchRef.set(new CountDownLatch(1));
         schedulingResult = scheduler.scheduleOnce(requests, new ArrayList<VirtualMachineLease>());
@@ -582,9 +597,9 @@ public class AutoScalerTest {
         attributes2.put(hostAttrName, attribute2);
         List<VirtualMachineLease.Range> ports = new ArrayList<>();
         ports.add(new VirtualMachineLease.Range(1, 10));
-        for(int l=0; l<minIdle; l++) {
-            leases.add(LeaseProvider.getLeaseOffer("smallhost"+l, cpus1, memory1, ports, attributes1));
-            leases.add(LeaseProvider.getLeaseOffer("bighost"+l, cpus2, memory2, ports, attributes2));
+        for (int l = 0; l < minIdle; l++) {
+            leases.add(LeaseProvider.getLeaseOffer("smallhost" + l, cpus1, memory1, ports, attributes1));
+            leases.add(LeaseProvider.getLeaseOffer("bighost" + l, cpus2, memory2, ports, attributes2));
         }
         // fill the big hosts, there's no autoscale rule for it
         // make small tasks sticky on small hosts with a constraint
@@ -594,7 +609,7 @@ public class AutoScalerTest {
                 return hostAttrVal1;
             }
         });
-        for(int h=0; h<leases.size()/2; h++) {
+        for (int h = 0; h < leases.size() / 2; h++) {
             requests.add(TaskRequestProvider.getTaskRequest(6.0, 100, 1));
             requests.add(TaskRequestProvider.getTaskRequest(1.0, 10, 1, Collections.singletonList(attrConstraint), null));
         }
@@ -606,7 +621,7 @@ public class AutoScalerTest {
                 switch (action.getRuleName()) {
                     case hostAttrVal1:
                         System.out.println("Got scale up for small hosts " + System.currentTimeMillis());
-                        hostsToAdd.set(((ScaleUpAction)action).getScaleUpCount());
+                        hostsToAdd.set(((ScaleUpAction) action).getScaleUpCount());
                         latchSmallHosts.countDown();
                         break;
                     case hostAttrVal2:
@@ -617,9 +632,9 @@ public class AutoScalerTest {
                 }
             }
         });
-        for(int i=0; i<coolDownSecs+2; i++) {
+        for (int i = 0; i < coolDownSecs + 2; i++) {
             final SchedulingResult schedulingResult = scheduler.scheduleOnce(requests, leases);
-            if(i==0) {
+            if (i == 0) {
                 //Assert.assertTrue(schedulingResult.getFailures().isEmpty());
                 int successes = 0;
                 final Map<String, VMAssignmentResult> resultMap = schedulingResult.getResultMap();
@@ -628,7 +643,7 @@ public class AutoScalerTest {
                         if (r.isSuccessful()) {
                             successes++;
                             scheduler.getTaskAssigner().call(r.getRequest(), entry.getKey());
-                            switch ((int)r.getRequest().getCPUs()) {
+                            switch ((int) r.getRequest().getCPUs()) {
                                 case 1:
                                     Assert.assertTrue("Expecting assignment on small host", entry.getKey().startsWith("smallhost"));
                                     break;
@@ -646,11 +661,11 @@ public class AutoScalerTest {
             }
             Thread.sleep(1000);
         }
-        if(!latchSmallHosts.await(5, TimeUnit.SECONDS))
+        if (!latchSmallHosts.await(5, TimeUnit.SECONDS))
             Assert.fail("Small hosts scale up not triggered");
-        Assert.assertTrue("Small hosts to add>0", hostsToAdd.get()>0);
-        for(int i=0; i<hostsToAdd.get(); i++)
-            leases.add(LeaseProvider.getLeaseOffer("smallhost"+100+i, cpus1, memory1, ports, attributes1));
+        Assert.assertTrue("Small hosts to add>0", hostsToAdd.get() > 0);
+        for (int i = 0; i < hostsToAdd.get(); i++)
+            leases.add(LeaseProvider.getLeaseOffer("smallhost" + 100 + i, cpus1, memory1, ports, attributes1));
         final CountDownLatch latchBigHosts = new CountDownLatch(1);
         scheduler.addOrReplaceAutoScaleRule(AutoScaleRuleProvider.createRule(hostAttrVal2, minIdle, maxIdle, coolDownSecs, 1, 1000));
         scheduler.setAutoscalerCallback(new Action1<AutoScaleAction>() {
@@ -669,14 +684,14 @@ public class AutoScalerTest {
                 }
             }
         });
-        for(int i=0; i<coolDownSecs+2; i++) {
+        for (int i = 0; i < coolDownSecs + 2; i++) {
             scheduler.scheduleOnce(requests, leases);
             if (i == 0) {
                 leases.clear();
             }
             Thread.sleep(1000);
         }
-        if(!latchBigHosts.await(5, TimeUnit.SECONDS))
+        if (!latchBigHosts.await(5, TimeUnit.SECONDS))
             Assert.fail("Big hosts scale up not triggered");
     }
 
@@ -692,10 +707,10 @@ public class AutoScalerTest {
         attributes1.put(hostAttrName, attribute1);
         List<VirtualMachineLease.Range> ports = new ArrayList<>();
         ports.add(new VirtualMachineLease.Range(1, 10));
-        for(int l=0; l<minIdle; l++) {
-            leases.add(LeaseProvider.getLeaseOffer("smallhost"+l, cpus1, memory1, ports, attributes1));
+        for (int l = 0; l < minIdle; l++) {
+            leases.add(LeaseProvider.getLeaseOffer("smallhost" + l, cpus1, memory1, ports, attributes1));
         }
-        for(int h=0; h<leases.size()/2; h++) {
+        for (int h = 0; h < leases.size() / 2; h++) {
             requests.add(TaskRequestProvider.getTaskRequest(3.0, 100, 1));
         }
         final CountDownLatch latch = new CountDownLatch(1);
@@ -709,9 +724,9 @@ public class AutoScalerTest {
                 }
             }
         });
-        for(int i=0; i<coolDownSecs+2 && keepGoing.get(); i++) {
+        for (int i = 0; i < coolDownSecs + 2 && keepGoing.get(); i++) {
             final SchedulingResult schedulingResult = scheduler.scheduleOnce(requests, leases);
-            if(i==0) {
+            if (i == 0) {
                 //Assert.assertTrue(schedulingResult.getFailures().isEmpty());
                 int successes = 0;
                 final Map<String, VMAssignmentResult> resultMap = schedulingResult.getResultMap();
@@ -728,7 +743,7 @@ public class AutoScalerTest {
             }
             Thread.sleep(1000);
         }
-        if(!latch.await(2, TimeUnit.SECONDS))
+        if (!latch.await(2, TimeUnit.SECONDS))
             Assert.fail("Didn't get scale up action");
         scheduler.removeAutoScaleRule(hostAttrVal1);
         scheduler.addOrReplaceAutoScaleRule(AutoScaleRuleProvider.createRule(hostAttrVal2, minIdle, maxIdle, coolDownSecs, 1, 1000));
@@ -736,7 +751,7 @@ public class AutoScalerTest {
         scheduler.setAutoscalerCallback(new Action1<AutoScaleAction>() {
             @Override
             public void call(AutoScaleAction action) {
-                if(action.getType() == AutoScaleAction.Type.Up) {
+                if (action.getType() == AutoScaleAction.Type.Up) {
                     switch (action.getRuleName()) {
                         case hostAttrVal1:
                             Assert.fail("Shouldn't have gotten autoscale action");
@@ -748,7 +763,7 @@ public class AutoScalerTest {
                 }
             }
         });
-        for(int i=0; i<coolDownSecs+2; i++) {
+        for (int i = 0; i < coolDownSecs + 2; i++) {
             scheduler.scheduleOnce(requests, leases);
             Thread.sleep(1000);
         }
@@ -756,8 +771,8 @@ public class AutoScalerTest {
     }
 
     private boolean isInCollection(String host, Collection<String> hostList) {
-        for(String h: hostList)
-            if(h.equals(host))
+        for (String h : hostList)
+            if (h.equals(host))
                 return true;
         return false;
     }
@@ -800,31 +815,30 @@ public class AutoScalerTest {
                 .setText(Protos.Value.Text.newBuilder().setValue(hostAttrVal1)).build();
         attributes.put(hostAttrName, attribute);
         final List<VirtualMachineLease> leases = new ArrayList<>();
-        for(int l=0; l<minIdle; l++)
-            leases.add(LeaseProvider.getLeaseOffer("host"+l, cpus1, memory1, ports, attributes));
-        for(int i=0; i<coolDownSecs+1; i++) {
-            if(i>0)
+        for (int l = 0; l < minIdle; l++)
+            leases.add(LeaseProvider.getLeaseOffer("host" + l, cpus1, memory1, ports, attributes));
+        for (int i = 0; i < coolDownSecs + 1; i++) {
+            if (i > 0)
                 leases.clear();
             final SchedulingResult result = scheduler.scheduleOnce(Collections.<TaskRequest>emptyList(), leases);
             Thread.sleep(1000);
         }
         Assert.assertFalse("Unexpected to scale DOWN", scaleDownReceived.get());
         Assert.assertFalse("Unexpected to scale UP", scaleUpReceived.get());
-        for(int o=0; o<N; o++) {
-            if(o==1)
-                Thread.sleep((long)(2.5 * scaleupDelaySecs)*1000L); // delay next round by a while to reset previous delay
-            for(int i=0; i<scaleupDelaySecs+2; i++) {
+        for (int o = 0; o < N; o++) {
+            if (o == 1)
+                Thread.sleep((long) (2.5 * scaleupDelaySecs) * 1000L); // delay next round by a while to reset previous delay
+            for (int i = 0; i < scaleupDelaySecs + 2; i++) {
                 List<TaskRequest> tasks = new ArrayList<>();
-                if(i==0) {
+                if (i == 0) {
                     tasks.add(TaskRequestProvider.getTaskRequest(1, 1000, 1));
                 }
                 final SchedulingResult result = scheduler.scheduleOnce(tasks, leases);
                 final Map<String, VMAssignmentResult> resultMap = result.getResultMap();
-                if(!tasks.isEmpty()) {
+                if (!tasks.isEmpty()) {
                     Assert.assertTrue(resultMap.size() == 1);
                     leases.add(LeaseProvider.getConsumedLease(resultMap.values().iterator().next()));
-                }
-                else
+                } else
                     leases.clear();
                 Thread.sleep(1000);
             }
@@ -865,7 +879,7 @@ public class AutoScalerTest {
                 }
             }
         };
-        long scaleDownDelay=3;
+        long scaleDownDelay = 3;
         TaskScheduler scheduler = getScheduler(noOpLeaseReject, callback, 0, scaleDownDelay, rule1);
         List<VirtualMachineLease.Range> ports = new ArrayList<>();
         ports.add(new VirtualMachineLease.Range(1, 10));
@@ -875,10 +889,10 @@ public class AutoScalerTest {
                 .setText(Protos.Value.Text.newBuilder().setValue(hostAttrVal1)).build();
         attributes.put(hostAttrName, attribute);
         final List<VirtualMachineLease> leases = new ArrayList<>();
-        for(int l=0; l<maxIdle+2; l++)
-            leases.add(LeaseProvider.getLeaseOffer("host"+l, cpus1, memory1, ports, attributes));
+        for (int l = 0; l < maxIdle + 2; l++)
+            leases.add(LeaseProvider.getLeaseOffer("host" + l, cpus1, memory1, ports, attributes));
         List<TaskRequest> tasks = new ArrayList<>();
-        for(int t=0; t<2; t++)
+        for (int t = 0; t < 2; t++)
             tasks.add(TaskRequestProvider.getTaskRequest(cpus1, memory1, 1));
         final SchedulingResult result = scheduler.scheduleOnce(tasks, leases);
         final Map<String, VMAssignmentResult> resultMap = result.getResultMap();
@@ -889,22 +903,21 @@ public class AutoScalerTest {
         // mark completion of 1 task; add back one of the leases
         leases.add(resultMap.values().iterator().next().getLeasesUsed().iterator().next());
         // run scheduler for (scaleDownDelay-1) secs and ensure we didn't get scale down request
-        for(int i=0; i<scaleDownDelay-1; i++) {
+        for (int i = 0; i < scaleDownDelay - 1; i++) {
             scheduler.scheduleOnce(tasks, leases);
-            if(i==0)
+            if (i == 0)
                 leases.clear();
             Thread.sleep(1000);
         }
         Assert.assertFalse("Scale down not expected", scaleDownReceived.get());
         Assert.assertFalse("Scale up not expected", scaleUpReceived.get());
-        for(int o=0; o<N; o++) {
-            if(o==1) {
+        for (int o = 0; o < N; o++) {
+            if (o == 1) {
                 Thread.sleep((long) (2.5 * scaleDownDelay) * 1000L);
                 leases.add(LeaseProvider.getLeaseOffer("hostFoo", cpus1, memory1, ports, attributes));
-            }
-            else
+            } else
                 tasks.add(TaskRequestProvider.getTaskRequest(cpus1, memory1, 1));
-            for (int i = 0; i < scaleDownDelay+1; i++) {
+            for (int i = 0; i < scaleDownDelay + 1; i++) {
                 final SchedulingResult result1 = scheduler.scheduleOnce(tasks, leases);
                 leases.clear();
                 if (!tasks.isEmpty()) {
@@ -917,8 +930,8 @@ public class AutoScalerTest {
             Assert.assertFalse("Scale up not expected", scaleUpReceived.get());
         }
         // ensure normal scale down request happens after the delay
-        for(int l=0; l<N; l++)
-            leases.add(LeaseProvider.getLeaseOffer("host"+(100+l), cpus1, memory1, ports, attributes));
+        for (int l = 0; l < N; l++)
+            leases.add(LeaseProvider.getLeaseOffer("host" + (100 + l), cpus1, memory1, ports, attributes));
         SchedulingResult result1 = scheduler.scheduleOnce(Collections.<TaskRequest>emptyList(), leases);
         leases.clear();
         Thread.sleep(1000);
@@ -929,9 +942,9 @@ public class AutoScalerTest {
     // Test that with a rule that has min size defined, we don't try to scale down below the min size, even though there are too many idle
     @Test
     public void testRuleWithMinSize() throws Exception {
-        final int minSize=10;
-        final int extra=2;
-        long cooldown=2;
+        final int minSize = 10;
+        final int extra = 2;
+        long cooldown = 2;
         AutoScaleRule rule = AutoScaleRuleProvider.createWithMinSize("cluster1", 2, 5, cooldown, 1.0, 1000, minSize);
         Map<String, Protos.Attribute> attributes = new HashMap<>();
         Protos.Attribute attribute = Protos.Attribute.newBuilder().setName(hostAttrName)
@@ -941,16 +954,16 @@ public class AutoScalerTest {
         ports.add(new VirtualMachineLease.Range(1, 10));
         attributes.put(hostAttrName, attribute);
         final List<VirtualMachineLease> leases = new ArrayList<>();
-        for(int l=0; l<minSize+extra; l++)
-            leases.add(LeaseProvider.getLeaseOffer("host"+l, 4, 4000, ports, attributes));
+        for (int l = 0; l < minSize + extra; l++)
+            leases.add(LeaseProvider.getLeaseOffer("host" + l, 4, 4000, ports, attributes));
         AtomicInteger scaleDown = new AtomicInteger();
         Action1<AutoScaleAction> callback = autoScaleAction -> {
             if (autoScaleAction instanceof ScaleDownAction) {
-                scaleDown.addAndGet(((ScaleDownAction)autoScaleAction).getHosts().size());
+                scaleDown.addAndGet(((ScaleDownAction) autoScaleAction).getHosts().size());
             }
         };
         final TaskScheduler scheduler = getScheduler(noOpLeaseReject, callback, rule);
-        for (int i=0; i<cooldown+1; i++) {
+        for (int i = 0; i < cooldown + 1; i++) {
             scheduler.scheduleOnce(Collections.emptyList(), leases);
             leases.clear();
             Thread.sleep(1000);
@@ -961,8 +974,8 @@ public class AutoScalerTest {
     // Test that with a rule that has min size defined, we don't try to scale down at all if total size < minSize, even though there are too many idle
     @Test
     public void testRuleWithMinSize2() throws Exception {
-        final int minSize=10;
-        long cooldown=2;
+        final int minSize = 10;
+        long cooldown = 2;
         AutoScaleRule rule = AutoScaleRuleProvider.createWithMinSize("cluster1", 2, 5, cooldown, 1.0, 1000, minSize);
         Map<String, Protos.Attribute> attributes = new HashMap<>();
         Protos.Attribute attribute = Protos.Attribute.newBuilder().setName(hostAttrName)
@@ -972,16 +985,16 @@ public class AutoScalerTest {
         ports.add(new VirtualMachineLease.Range(1, 10));
         attributes.put(hostAttrName, attribute);
         final List<VirtualMachineLease> leases = new ArrayList<>();
-        for(int l=0; l<minSize-2; l++)
-            leases.add(LeaseProvider.getLeaseOffer("host"+l, 4, 4000, ports, attributes));
+        for (int l = 0; l < minSize - 2; l++)
+            leases.add(LeaseProvider.getLeaseOffer("host" + l, 4, 4000, ports, attributes));
         AtomicInteger scaleDown = new AtomicInteger();
         Action1<AutoScaleAction> callback = autoScaleAction -> {
             if (autoScaleAction instanceof ScaleDownAction) {
-                scaleDown.addAndGet(((ScaleDownAction)autoScaleAction).getHosts().size());
+                scaleDown.addAndGet(((ScaleDownAction) autoScaleAction).getHosts().size());
             }
         };
         final TaskScheduler scheduler = getScheduler(noOpLeaseReject, callback, rule);
-        for (int i=0; i<cooldown+1; i++) {
+        for (int i = 0; i < cooldown + 1; i++) {
             scheduler.scheduleOnce(Collections.emptyList(), leases);
             leases.clear();
             Thread.sleep(1000);
@@ -992,9 +1005,9 @@ public class AutoScalerTest {
     // Test that with a rule that has the max size defined, we don't try to scale up beyond the max, even if there's not enough idle
     @Test
     public void testRuleWithMaxSize() throws Exception {
-        final int maxSize=10;
-        final int leaveIdle=2;
-        final long cooldown=2;
+        final int maxSize = 10;
+        final int leaveIdle = 2;
+        final long cooldown = 2;
         final AutoScaleRule rule = AutoScaleRuleProvider.createWithMaxSize("cluster1", leaveIdle * 2, leaveIdle * 2 + 1, cooldown, 1, 1000, maxSize);
         Map<String, Protos.Attribute> attributes = new HashMap<>();
         Protos.Attribute attribute = Protos.Attribute.newBuilder().setName(hostAttrName)
@@ -1004,8 +1017,8 @@ public class AutoScalerTest {
         ports.add(new VirtualMachineLease.Range(1, 10));
         attributes.put(hostAttrName, attribute);
         final List<VirtualMachineLease> leases = new ArrayList<>();
-        for(int l=0; l<maxSize-leaveIdle; l++)
-            leases.add(LeaseProvider.getLeaseOffer("host"+l, 4, 4000, ports, attributes));
+        for (int l = 0; l < maxSize - leaveIdle; l++)
+            leases.add(LeaseProvider.getLeaseOffer("host" + l, 4, 4000, ports, attributes));
         AtomicInteger scaleUp = new AtomicInteger();
         Action1<AutoScaleAction> callback = autoScaleAction -> {
             if (autoScaleAction instanceof ScaleUpAction) {
@@ -1016,23 +1029,23 @@ public class AutoScalerTest {
         final TaskScheduler scheduler = getScheduler(noOpLeaseReject, callback, rule);
         // create enough tasks to fill up the Vms
         List<TaskRequest> tasks = new ArrayList<>();
-        for (int l=0; l<maxSize-leaveIdle; l++)
+        for (int l = 0; l < maxSize - leaveIdle; l++)
             tasks.add(TaskRequestProvider.getTaskRequest(4, 4000, 1));
-        boolean first=true;
-        for (int i=0; i<cooldown+1; i++) {
+        boolean first = true;
+        for (int i = 0; i < cooldown + 1; i++) {
             final SchedulingResult result = scheduler.scheduleOnce(tasks, leases);
             if (first) {
                 first = false;
                 leases.clear();
-                int assigned=0;
-                Assert.assertTrue(result.getResultMap().size()>0);
-                for(VMAssignmentResult r: result.getResultMap().values()) {
-                    for (TaskAssignmentResult task: r.getTasksAssigned()) {
+                int assigned = 0;
+                Assert.assertTrue(result.getResultMap().size() > 0);
+                for (VMAssignmentResult r : result.getResultMap().values()) {
+                    for (TaskAssignmentResult task : r.getTasksAssigned()) {
                         assigned++;
                         scheduler.getTaskAssigner().call(task.getRequest(), r.getHostname());
                     }
                 }
-                Assert.assertEquals(maxSize-leaveIdle, assigned);
+                Assert.assertEquals(maxSize - leaveIdle, assigned);
                 tasks.clear();
             }
             Thread.sleep(1000);
@@ -1043,8 +1056,8 @@ public class AutoScalerTest {
     // Test that with a rule that has the max size defined, we don't try to scale up at all if total size > maxSize, even if there's no idle left
     @Test
     public void testRuleWithMaxSize2() throws Exception {
-        final int maxSize=10;
-        final long cooldown=2;
+        final int maxSize = 10;
+        final long cooldown = 2;
         final AutoScaleRule rule = AutoScaleRuleProvider.createWithMaxSize("cluster1", 2, 5, cooldown, 1, 1000, maxSize);
         Map<String, Protos.Attribute> attributes = new HashMap<>();
         Protos.Attribute attribute = Protos.Attribute.newBuilder().setName(hostAttrName)
@@ -1054,8 +1067,8 @@ public class AutoScalerTest {
         ports.add(new VirtualMachineLease.Range(1, 10));
         attributes.put(hostAttrName, attribute);
         final List<VirtualMachineLease> leases = new ArrayList<>();
-        for(int l=0; l<maxSize+2; l++)
-            leases.add(LeaseProvider.getLeaseOffer("host"+l, 4, 4000, ports, attributes));
+        for (int l = 0; l < maxSize + 2; l++)
+            leases.add(LeaseProvider.getLeaseOffer("host" + l, 4, 4000, ports, attributes));
         AtomicInteger scaleUp = new AtomicInteger();
         Action1<AutoScaleAction> callback = autoScaleAction -> {
             if (autoScaleAction instanceof ScaleUpAction) {
@@ -1066,23 +1079,23 @@ public class AutoScalerTest {
         final TaskScheduler scheduler = getScheduler(noOpLeaseReject, callback, rule);
         // create enough tasks to fill up the Vms
         List<TaskRequest> tasks = new ArrayList<>();
-        for (int l=0; l<maxSize+2; l++)
+        for (int l = 0; l < maxSize + 2; l++)
             tasks.add(TaskRequestProvider.getTaskRequest(4, 4000, 1));
-        boolean first=true;
-        for (int i=0; i<cooldown+1; i++) {
+        boolean first = true;
+        for (int i = 0; i < cooldown + 1; i++) {
             final SchedulingResult result = scheduler.scheduleOnce(tasks, leases);
             if (first) {
                 first = false;
                 leases.clear();
-                int assigned=0;
-                Assert.assertTrue(result.getResultMap().size()>0);
-                for(VMAssignmentResult r: result.getResultMap().values()) {
-                    for (TaskAssignmentResult task: r.getTasksAssigned()) {
+                int assigned = 0;
+                Assert.assertTrue(result.getResultMap().size() > 0);
+                for (VMAssignmentResult r : result.getResultMap().values()) {
+                    for (TaskAssignmentResult task : r.getTasksAssigned()) {
                         assigned++;
                         scheduler.getTaskAssigner().call(task.getRequest(), r.getHostname());
                     }
                 }
-                Assert.assertEquals(maxSize+2, assigned);
+                Assert.assertEquals(maxSize + 2, assigned);
                 tasks.clear();
             }
             Thread.sleep(1000);
@@ -1095,9 +1108,9 @@ public class AutoScalerTest {
     // aggressive scale up.
     @Test
     public void testTask2ClustersGetterAggressiveScaleUp() throws Exception {
-        final long cooldownMillis=3000;
-        final AutoScaleRule rule1 = AutoScaleRuleProvider.createRule("cluster1", minIdle, maxIdle, cooldownMillis/1000L, 1, 1000);
-        final AutoScaleRule rule2 = AutoScaleRuleProvider.createRule("cluster2", minIdle, maxIdle, cooldownMillis/1000L, 1, 1000);
+        final long cooldownMillis = 3000;
+        final AutoScaleRule rule1 = AutoScaleRuleProvider.createRule("cluster1", minIdle, maxIdle, cooldownMillis / 1000L, 1, 1000);
+        final AutoScaleRule rule2 = AutoScaleRuleProvider.createRule("cluster2", minIdle, maxIdle, cooldownMillis / 1000L, 1, 1000);
         Map<String, Protos.Attribute> attributes1 = new HashMap<>();
         Protos.Attribute attribute1 = Protos.Attribute.newBuilder().setName(hostAttrName)
                 .setType(Protos.Value.Type.TEXT)
@@ -1111,8 +1124,8 @@ public class AutoScalerTest {
                 .setText(Protos.Value.Text.newBuilder().setValue("cluster2")).build();
         attributes2.put(hostAttrName, attribute1);
         final List<VirtualMachineLease> leases = new ArrayList<>();
-        for(int l=0; l<minIdle; l++)
-            leases.add(LeaseProvider.getLeaseOffer("host"+l, cpus1, memory1, ports, attributes1));
+        for (int l = 0; l < minIdle; l++)
+            leases.add(LeaseProvider.getLeaseOffer("host" + l, cpus1, memory1, ports, attributes1));
         final Map<String, Integer> scaleUpRequests = new HashMap<>();
         final CountDownLatch initialScaleUpLatch = new CountDownLatch(2);
         final AtomicReference<CountDownLatch> scaleUpLatchRef = new AtomicReference<>();
@@ -1135,7 +1148,7 @@ public class AutoScalerTest {
         final TaskSchedulingService schedulingService = new TaskSchedulingService.Builder()
                 .withMaxDelayMillis(100)
                 .withLoopIntervalMillis(20)
-                .withTaskQuue(queue)
+                .withTaskQueue(queue)
                 .withTaskScheduler(scheduler)
                 .withSchedulingResultCallback(schedulingResult -> {
                     final List<Exception> elist = schedulingResult.getExceptions();
@@ -1143,7 +1156,7 @@ public class AutoScalerTest {
                         exceptions.set(elist);
                     final Map<String, VMAssignmentResult> resultMap = schedulingResult.getResultMap();
                     if (resultMap != null && !resultMap.isEmpty()) {
-                        for (VMAssignmentResult vmar: resultMap.values()) {
+                        for (VMAssignmentResult vmar : resultMap.values()) {
                             vmar.getTasksAssigned().forEach(t -> latch.countDown());
                         }
                     }
@@ -1152,7 +1165,7 @@ public class AutoScalerTest {
         schedulingService.setTaskToClusterAutoScalerMapGetter(task -> Collections.singletonList("cluster1"));
         schedulingService.start();
         schedulingService.addLeases(leases);
-        for (int i=0; i<numTasks; i++)
+        for (int i = 0; i < numTasks; i++)
             queue.queueTask(
                     QueuableTaskProvider.wrapTask(
                             new QAttributes.QAttributesAdaptor(0, "default"),
@@ -1162,14 +1175,14 @@ public class AutoScalerTest {
         if (!latch.await(10, TimeUnit.SECONDS))
             Assert.fail("Timeout waiting for tasks to get assigned");
         // wait for scale up to happen
-        if (!initialScaleUpLatch.await(cooldownMillis+1000, TimeUnit.MILLISECONDS))
+        if (!initialScaleUpLatch.await(cooldownMillis + 1000, TimeUnit.MILLISECONDS))
             Assert.fail("Timeout waiting for initial scale up request");
         Assert.assertEquals(2, scaleUpRequests.size());
         scaleUpRequests.clear();
         scaleUpLatchRef.set(null);
         // now submit more tasks for aggressive scale up to trigger
-        int laterTasksSize = numTasks*3;
-        for (int i=0; i<laterTasksSize; i++) {
+        int laterTasksSize = numTasks * 3;
+        for (int i = 0; i < laterTasksSize; i++) {
             queue.queueTask(
                     QueuableTaskProvider.wrapTask(
                             new QAttributes.QAttributesAdaptor(0, "default"),
@@ -1178,10 +1191,87 @@ public class AutoScalerTest {
             );
         }
         // wait for less than cooldown time to get aggressive scale up requests
-        Thread.sleep(cooldownMillis/2);
+        Thread.sleep(cooldownMillis / 2);
         // expect to get scale up request only for cluster1 VMs
         Assert.assertEquals(1, scaleUpRequests.size());
         Assert.assertEquals("cluster1", scaleUpRequests.keySet().iterator().next());
         Assert.assertEquals(laterTasksSize, scaleUpRequests.values().iterator().next().intValue());
+    }
+
+    // Test that when blocking the autoscaler callback, tasks are not scheduled on machines that are scheduled to be terminated
+    @Test
+    public void testAutoscalerBlockingCallback() throws Exception {
+        int minIdle = 1;
+        int maxIdle = 1;
+        int numberOfHostsPerCluster = maxIdle * 2;
+        final long cooldownMillis = 1_000;
+        final String CLUSTER1 = "cluster1";
+        final String CLUSTER2 = "cluster2";
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
+
+        // create autoscaling rules for 2 clusters
+        final AutoScaleRule cluster1Rule = AutoScaleRuleProvider.createWithMaxSize(CLUSTER1, minIdle, maxIdle, cooldownMillis / 1000L, 1, 1000, numberOfHostsPerCluster);
+        final AutoScaleRule cluster2Rule = AutoScaleRuleProvider.createWithMaxSize(CLUSTER2, minIdle, maxIdle, cooldownMillis / 1000L, 1, 1000, numberOfHostsPerCluster);
+
+        // create the maxIdle * 2 leases (machines) for each cluster
+        Map<String, Protos.Attribute> attributes1 = new HashMap<>();
+        Protos.Attribute attribute1 = Protos.Attribute.newBuilder().setName(hostAttrName)
+                .setType(Protos.Value.Type.TEXT)
+                .setText(Protos.Value.Text.newBuilder().setValue(CLUSTER1)).build();
+        List<VirtualMachineLease.Range> ports = new ArrayList<>();
+        ports.add(new VirtualMachineLease.Range(1, 10));
+        attributes1.put(hostAttrName, attribute1);
+
+        Map<String, Protos.Attribute> attributes2 = new HashMap<>();
+        Protos.Attribute attribute2 = Protos.Attribute.newBuilder().setName(hostAttrName)
+                .setType(Protos.Value.Type.TEXT)
+                .setText(Protos.Value.Text.newBuilder().setValue(CLUSTER2)).build();
+        attributes2.put(hostAttrName, attribute2);
+        final List<VirtualMachineLease> leases = new ArrayList<>();
+
+        for (int l = 0; l < numberOfHostsPerCluster; l++) {
+            leases.add(LeaseProvider.getLeaseOffer("cluster1Host" + l, cpus1, memory1, ports, attributes1));
+            leases.add(LeaseProvider.getLeaseOffer("cluster2Host" + l, cpus1, memory1, ports, attributes2));
+        }
+
+        // create task scheduler with a callback action that blocks for 100ms
+        Set<String> hostsToScaleDown = new HashSet<>();
+        Action1<AutoScaleAction> callback = action -> {
+            try {
+                if (action instanceof ScaleDownAction) {
+                    ScaleDownAction scaleDownAction = (ScaleDownAction) action;
+                    hostsToScaleDown.addAll(scaleDownAction.getHosts());
+                    countDownLatch.countDown();
+                    Thread.sleep(100);
+                }
+
+            } catch (InterruptedException ignored) {
+            }
+        };
+        final TaskScheduler scheduler = getScheduler(noOpLeaseReject, callback, cluster1Rule, cluster2Rule);
+
+        // run a scheduling iteration and wait until the callback is called
+        scheduler.scheduleOnce(Collections.emptyList(), leases);
+        while (countDownLatch.getCount() != 1) {
+            Thread.sleep(10);
+            scheduler.scheduleOnce(Collections.emptyList(), Collections.emptyList());
+        }
+
+        // create maxIdle tasks that each fill up a machine and run scheduling iteration
+        final List<TaskRequest> requests = new ArrayList<>();
+        for (int i = 0; i < (numberOfHostsPerCluster * 1.5); i++) {
+            requests.add(TaskRequestProvider.getTaskRequest(cpus1, memory1, 0));
+        }
+
+        SchedulingResult schedulingResult = scheduler.scheduleOnce(requests, Collections.emptyList());
+
+        // verify that half of the tasks failed placement as half of the instances should have been disabled by the autoscaler
+        int expectedFailures = numberOfHostsPerCluster / 2;
+        Map<TaskRequest, List<TaskAssignmentResult>> failures = schedulingResult.getFailures();
+        Assert.assertEquals(expectedFailures + " tasks should have failed placement", expectedFailures, failures.size());
+
+        // verify that none of the placements happened on a down scaled host
+        Map<String, VMAssignmentResult> resultMap = schedulingResult.getResultMap();
+        resultMap.values().forEach(result -> Assert.assertFalse(hostsToScaleDown.contains(result.getHostname())));
     }
 }

--- a/fenzo-core/src/test/java/com/netflix/fenzo/ShortfallAutoscalerTest.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/ShortfallAutoscalerTest.java
@@ -97,7 +97,7 @@ public class ShortfallAutoscalerTest {
                 .withMaxDelayMillis(500)
                 .withPreSchedulingLoopHook(preHook)
                 .withSchedulingResultCallback(resultCallback)
-                .withTaskQuue(queue)
+                .withTaskQueue(queue)
                 .withTaskScheduler(scheduler)
                 .withOptimizingShortfallEvaluator()
                 .build();

--- a/fenzo-core/src/test/java/com/netflix/fenzo/TaskSchedulingServiceTest.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/TaskSchedulingServiceTest.java
@@ -48,7 +48,7 @@ public class TaskSchedulingServiceTest {
     private TaskSchedulingService getSchedulingService(TaskQueue queue, TaskScheduler scheduler, long loopMillis,
                                                        long maxDelayMillis, Action1<SchedulingResult> resultCallback) {
         return new TaskSchedulingService.Builder()
-                .withTaskQuue(queue)
+                .withTaskQueue(queue)
                 .withLoopIntervalMillis(loopMillis)
                 .withMaxDelayMillis(maxDelayMillis)
                 .withPreSchedulingLoopHook(new Action0() {

--- a/fenzo-core/src/test/java/com/netflix/fenzo/queues/tiered/TieredQueueTest.java
+++ b/fenzo-core/src/test/java/com/netflix/fenzo/queues/tiered/TieredQueueTest.java
@@ -362,7 +362,7 @@ public class TieredQueueTest {
     private TaskSchedulingService getSchedulingService(TaskQueue queue, TaskScheduler scheduler,
                                                        Action1<SchedulingResult> resultCallback) {
         return new TaskSchedulingService.Builder()
-                .withTaskQuue(queue)
+                .withTaskQueue(queue)
                 .withLoopIntervalMillis(100L)
                 .withPreSchedulingLoopHook(new Action0() {
                     @Override


### PR DESCRIPTION
- change autoscaler to be synchronously executed as part of the scheduling iteration while keeping the callback execution on a separate thread
- change shortfall analysis implementation to be synchronously executed as part of the autoscaler
- add withAutoscaleDisabledVmDurationInSecs for users that want to disable VMs for a fixed duration that is different from the cooldown value