### PR TITLE
Expose VM ids to fitness constraints and functions

### DIFF
--- a/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVirtualMachine.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/AssignableVirtualMachine.java
@@ -841,10 +841,17 @@ class AssignableVirtualMachine implements Comparable<AssignableVirtualMachine>{
             public String getHostname() {
                 return hostname;
             }
+
+            @Override
+            public String getVMId() {
+                return currVMId;
+            }
+
             @Override
             public Map<String, PreferentialNamedConsumableResourceSet> getResourceSets() {
                 return resourceSets;
             }
+
             @Override
             public VirtualMachineLease getCurrAvailableResources() {
                 return currTotalLease;
@@ -852,7 +859,6 @@ class AssignableVirtualMachine implements Comparable<AssignableVirtualMachine>{
 
             @Override
             public Collection<Protos.Offer> getAllCurrentOffers() {
-                System.out.println("****************************** ");
                 return offers;
             }
 
@@ -860,10 +866,12 @@ class AssignableVirtualMachine implements Comparable<AssignableVirtualMachine>{
             public Collection<TaskAssignmentResult> getTasksCurrentlyAssigned() {
                 return Collections.emptyList();
             }
+
             @Override
             public Collection<TaskRequest> getRunningTasks() {
                 return Collections.unmodifiableCollection(previouslyAssignedTasksMap.values());
             }
+
             @Override
             public long getDisabledUntil() {
                 return disabledUntil;
@@ -881,10 +889,17 @@ class AssignableVirtualMachine implements Comparable<AssignableVirtualMachine>{
             public String getHostname() {
                 return hostname;
             }
+
+            @Override
+            public String getVMId() {
+                return currVMId;
+            }
+
             @Override
             public Map<String, PreferentialNamedConsumableResourceSet> getResourceSets() {
                 return resourceSets;
             }
+
             @Override
             public VirtualMachineLease getCurrAvailableResources() {
                 return currTotalLease;
@@ -899,10 +914,12 @@ class AssignableVirtualMachine implements Comparable<AssignableVirtualMachine>{
             public Collection<TaskAssignmentResult> getTasksCurrentlyAssigned() {
                 return Collections.unmodifiableCollection(assignmentResults.values());
             }
+
             @Override
             public Collection<TaskRequest> getRunningTasks() {
                 return Collections.unmodifiableCollection(previouslyAssignedTasksMap.values());
             }
+
             @Override
             public long getDisabledUntil() {
                 return disabledUntil;

--- a/fenzo-core/src/main/java/com/netflix/fenzo/VirtualMachineCurrentState.java
+++ b/fenzo-core/src/main/java/com/netflix/fenzo/VirtualMachineCurrentState.java
@@ -36,6 +36,14 @@ public interface VirtualMachineCurrentState {
     String getHostname();
 
     /**
+     * Get the virtual machine id provided by the last seen {@link VirtualMachineLease lease} of this host.
+     *
+     * @return an identifier provided by the last {@link VirtualMachineLease}. It can be <tt>null</tt> when no leases
+     * were seen yet, or when leases do not include a VM id.
+     */
+    String getVMId();
+
+    /**
      * Get a map of resource sets of the virtual machine.
      *
      * @return The map of resource sets
@@ -53,6 +61,7 @@ public interface VirtualMachineCurrentState {
     /**
      * Get all offers for the VM that represent the available resources. There may be more than one offer over time
      * if Mesos master offered partial resources for the VM multiple times.
+     *
      * @return A collection of Mesos resource offers.
      */
     Collection<Protos.Offer> getAllCurrentOffers();
@@ -61,7 +70,7 @@ public interface VirtualMachineCurrentState {
      * Get list of task assignment results for this host so far in the current scheduling run.
      *
      * @return a collection of tasks that the current scheduling iteration assigned to this host but that are
-     *         not launched/executing yet
+     * not launched/executing yet
      */
     Collection<TaskAssignmentResult> getTasksCurrentlyAssigned();
 


### PR DESCRIPTION
In many cases, VM ids are more stable than hostnames (which are often IPs). Make the current VM id explicit, rather than forcing constraints and fitness functions to use VM attributes for it.