### PR TITLE
Remove usages of jcenter()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ ext.githubProjectName = 'Fenzo'
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -41,7 +41,7 @@ allprojects {
 subprojects {
     group = 'com.netflix.fenzo'
 
-    repositories { jcenter() }
+    repositories { mavenCentral() }
 
     apply plugin: 'nebula.dependency-lock'
     apply plugin: 'java'


### PR DESCRIPTION
Hi folks,

As you might be aware, JFrog is sunsetting Bintray and JCenter: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

This is to use maven central instead of jcenter